### PR TITLE
chore: remove reviewers from renovate

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -6,6 +6,8 @@
         ":dependencyDashboard",
         "config:base",
     ],
+    // Disable reviewers getting added by renovate to limit notification noise
+    "reviewersFromCodeOwners": false,
     "timezone": "America/New_York",
     "rebaseStalePrs": true,
     "schedule": ["after 7am and before 9am every weekday"],


### PR DESCRIPTION
Opening to start a discussion, or just merge. On PRs across UDS things the entire uds group gets tagged as a reviewers and gets emails about these PRs and any updates. I think it makes sense to disable the addition of reviewers to cut through the notification noise. Codeowners would still be required to approve/merge things, but this helps limit the noise to just participants in a PR. The downside is things could get lost for longer, but I think with proper structure around the team to review the dependency dashboard this should be mitigated.

Sidenote: I believe this ends up getting added by our extension of `config:base` which might be something to consider dropping instead.