### PR TITLE
chore: change the architecture in zarf package create to use UDS_ARCH

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -9,7 +9,7 @@ tasks:
       options:
         description: For setting create time variables and flags
     actions:
-      - cmd: uds zarf package create --confirm --no-progress --architecture=${ZARF_ARCHITECTURE} --flavor ${FLAVOR} ${{ .inputs.options }}
+      - cmd: uds zarf package create --confirm --no-progress --architecture=${UDS_ARCH} --flavor ${FLAVOR} ${{ .inputs.options }}
 
   - name: test-bundle
     description: Create the test UDS Bundle


### PR DESCRIPTION
This simply changes ZARF_ARCHITECTURE to UDS_ARCH (open for discussion and will require sibling PRs to uds-core, uds-package-gitlab, and likely others.