### PR TITLE
ci: k3d updates to be included in renovate PRs

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,6 +6,7 @@ runs:
   steps:
     - name: Install k3d
       shell: bash
+      # renovate: datasource=github-tags depName=k3d-io/k3d versioning=semver
       run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.0 bash
 
     - name: Set up Homebrew

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.cache/
+.idea/
+build/
+.DS_Store
+*.tar.zst
+zarf-sbom
+tmp/
+env.ts
+node_modules
+dist
+insecure*
+.env
+zarf
+tmp-tasks.yaml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pinning to a specific tag of a task (rather than `main`) with renovate watching 
 
 - UDS CLI: 0.9.2
 - UDS Core: 0.12.0
+- K3D: 5.6.0
 
 NOTE: Zarf is not required for tasks in this repo, the vendored zarf (`uds zarf`) included with UDS CLI is used instead to prevent version mismatches.
 

--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -58,6 +58,16 @@
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
             "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
         },
+        // Matches specified datasources where an environment variable separates the version on the following line (i.e. https://github.com/defenseunicorns/uds-common/blob/ce3ba974ef3ff88058809f4b9a78da281a65ffa0/.github/actions/setup/action.yaml#L9)
+        {
+            "fileMatch": [".*\\.ya?ml$"],
+            "matchStrings": [
+                // Test: https://regex101.com/r/b53bEF/1
+                "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*[A-Z]*=\\s*['\"]?(?<currentValue>[v0-9].*?)['\"]?(\\s|$)"
+            ],
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+            "extractVersionTemplate": "^v(?<version>.*)$"
+        },
         // Matches specified datasources for brew where an @ separates the version on the following line (i.e. https://github.com/defenseunicorns/uds-core/blob/5a2666f6a5ba89686c6dc1fecb0db98512b1b9f8/.github/actions/setup/action.yaml#L32)
         {
             "fileMatch": [".*\\.ya?ml$"],

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,15 @@
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "depNameTemplate": "k3d-io/k3d",
+      "fileMatch": ["README\\.md"],
+      "matchStrings": [
+        "- K3D: (?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
adding renovate config changes needed to keep k3d up to date and also adding a .gitignore