### PR TITLE
fix: fix UDS path

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -8,10 +8,20 @@ tasks:
     inputs:
       options:
         description: For setting create time variables and flags
+      path:
+        description: path for the zarf package to be created
+        default: ""
     actions:
-      - cmd: uds zarf package create --confirm --no-progress --architecture=${UDS_ARCH} --flavor ${FLAVOR} ${{ .inputs.options }}
+      - cmd: uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture=${UDS_ARCH} --flavor ${FLAVOR} ${{ .inputs.options }}
 
   - name: test-bundle
     description: Create the test UDS Bundle
+    inputs:
+      path:
+        description: Path relative to the repositories root where the uds-bundle.yaml lives
+        default: bundle
+      config:
+        description: File name of the bundle config file. Defaults to uds-config.yaml. Path is relative to the path input.
+        default: uds-config.yaml
     actions:
-      - cmd: uds create bundle --confirm --no-progress --architecture=${UDS_ARCH}
+      - cmd: UDS_CONFIG=${{ .inputs.path }}/${{ .inputs.config }} uds create ${{ .inputs.path }} --confirm --no-progress --architecture=${UDS_ARCH}

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -3,11 +3,21 @@ tasks:
     inputs:
       options:
         description: For setting deploy time variables and flags
+      path:
+        description: path of built zarf package to deploy
+        default: $(pwd)
     actions:
       - description: Deploy the UDS Zarf Package
-        cmd: uds zarf package deploy zarf-package-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress ${{ .inputs.options }}
+        cmd: uds zarf package deploy ${{ .inputs.path }}/zarf-package-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress ${{ .inputs.options }}
 
   - name: test-bundle
+    inputs:
+      path:
+        description: Path relative to the repositories root where the uds-bundle.yaml lives
+        default: bundle
+      config:
+        description: File name of the bundle config file. Defaults to uds-config.yaml. Path is relative to the path input.
+        default: uds-config.yaml
     actions:
       - description: Deploy the UDS bundle with the package and its dependencies
-        cmd: UDS_CONFIG=bundle/uds-config.yaml uds deploy bundle/uds-bundle-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress
+        cmd: UDS_CONFIG=${{ .inputs.path }}/${{ .inputs.config }} uds deploy ${{ .inputs.path }}/uds-bundle-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress


### PR DESCRIPTION
Fixes: https://github.com/defenseunicorns/uds-common/issues/54

<details><summary>cli command line options</summary>
<p>
```
➜  ~ uds create --help
Create a bundle from a given directory or the current directory

Usage:
  uds create [DIRECTORY] [flags]

Aliases:
  create, c

Flags:
  -c, --confirm                       REQUIRED. Confirm the removal action to prevent accidental deletions
  -h, --help                          help for create
  -o, --output string                 Specify the output (an oci:// URL) for the created bundle
  -k, --signing-key string            Path to private key file for signing bundles
  -p, --signing-key-password string   Password to the private key file used for signing bundles

Global Flags:
  -a, --architecture string   Architecture for UDS bundles and Zarf packages
      --insecure              Allow access to insecure registries and disable other recommended security enforcements such as package checksum and signature validation. This flag should only be used if you have a specific reason and accept the reduced security posture.
  -l, --log-level string      Log level when running UDS-CLI. Valid options are: warn, info, debug, trace (default "info")
      --no-log-file           Disable log file creation
      --no-progress           Disable fancy UI progress bars, spinners, logos, etc
      --oci-concurrency int   Number of concurrent layer operations to perform when interacting with a remote bundle. (default 3)
      --tmpdir string         Specify the temporary directory to use for intermediate files
      --uds-cache string      Specify the location of the Zarf cache directory (default "/Users/naveen/.uds-cache")
```
</p>
</details> 