### PR TITLE
chore: remove schedule on renovate

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -10,7 +10,6 @@
     "reviewersFromCodeOwners": false,
     "timezone": "America/New_York",
     "rebaseStalePrs": true,
-    "schedule": ["after 7am and before 9am every weekday"],
     "dependencyDashboard": true,
     "dependencyDashboardTitle": "Renovate Dashboard 🤖",
     "rebaseWhen": "conflicted",


### PR DESCRIPTION
Open to discussion on this - personally dislike using a schedule on the shared config. I think that could be done per-repo if people desire. I think it creates more confusion around why a certain update is not in a PR already.