### PR TITLE
chore: udpdate k3d-core-istio-dev to k3d-core-slim-dev

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -7,7 +7,7 @@ tasks:
     actions:
       - description: Create k3d cluster with UDS Core Istio
         # renovate: datasource=github-tags depName=defenseunicorns/uds-core versioning=semver
-        cmd: uds deploy oci://defenseunicorns/uds/bundles/k3d-core-istio-dev:0.16.1 --confirm --no-progress
+        cmd: uds deploy oci://defenseunicorns/uds/bundles/k3d-core-slim-dev:0.17.0 --confirm --no-progress
 
   - name: registry-login
     inputs:


### PR DESCRIPTION
Update setup task to deploy new k3d-core-slim-dev instead of k3d-core-istio-dev

Tested it locally with 'uds run setup:k3d-test-cluster' and verified I can 'zarf connect keycloak'

![image](https://github.com/defenseunicorns/uds-common/assets/23637493/0cf21425-317a-46bb-9e43-a9b416994a2c)
