### PR TITLE
chore: add an airgap note to UDS Package Practices (clarity is kindness)

### DIFF
--- a/docs/uds-package-practices.md
+++ b/docs/uds-package-practices.md
@@ -74,3 +74,9 @@ To help maintain a UDS Package, it:
 - **Must** have a dependency management bot (such as renovate) configured to open PRs to update core package and support dependencies.
 
 - **Must** release its package to the `ghcr.io/defenseunicorns/packages/<group>` namespace as the application's name (i.e. `ghcr.io/defenseunicorns/packages/uds/mattermost`)
+
+## General
+
+And in addition to the above, packages generally:
+
+- **Must** be capable of operating within an internet-disconnected (air-gapped) environment


### PR DESCRIPTION
This adds a note clarifying that UDS Packages must be capable of operating offline.