### PR TITLE
fix: update renovate config to use docker versioning for zarf images

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -96,7 +96,7 @@
                 // Test: https://regex101.com/r/Bd8IBp/1
                 "- ['\"]?(?<depName>[^\"'\\s]+):(?<currentValue>[^\"'\\s]+)['\"]?( # renovate:( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?)?(\\s|$)"
             ],
-            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}",
             "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}",
             "datasourceTemplate": "docker"
         },


### PR DESCRIPTION
Context is mostly included in the linked issue. TLDR - helm-values uses `docker` versioning so this aligns the two places we reference images.

Closes https://github.com/defenseunicorns/uds-common/issues/127