### PR TITLE
fix: renovate incorrectly matching oci helm charts for helm datasources

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -123,8 +123,8 @@
                 "(?m)charts:(.|\\n)*?(^\\s{4}[\\w:]+|\\n$|^\\s{2}-)",
                 // Match a chart entry. Test: https://regex101.com/r/ibpxYd/1
                 "(?m)name:(.|\\n)+?(^\\s{4}[\\w\\-:]+|\\n$|^\\s{2}-|^\\s{6}-)",
-                // Match the parts of a chart entry. Test: https://regex101.com/r/GgGbkM/1
-                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file|git):\\/\\/.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$"
+                // Match the parts of a chart entry. Test: https://regex101.com/r/ehfBW6/1
+                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file):\\/\\/.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$"
             ],
             "datasourceTemplate": "helm"
         },

--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -109,8 +109,8 @@
                 "(?m)charts:(.|\\n)*?(^\\s{4}[\\w:]+|\\n$|^\\s{2}-)",
                 // Match a chart entry. Test: https://regex101.com/r/ibpxYd/1
                 "(?m)name:(.|\\n)+?(^\\s{4}[\\w\\-:]+|\\n$|^\\s{2}-|^\\s{6}-)",
-                // Match the parts of a chart entry. Test: https://regex101.com/r/nruXFi/1
-                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>.+?)[\"']?$"
+                // Match the parts of a chart entry. Test: https://regex101.com/r/2BhQd2/1
+                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file|git):\\/\\/.+?)[\"']?$"
             ],
             "datasourceTemplate": "helm"
         },
@@ -123,8 +123,8 @@
                 "(?m)charts:(.|\\n)*?(^\\s{4}[\\w:]+|\\n$|^\\s{2}-)",
                 // Match a chart entry. Test: https://regex101.com/r/ibpxYd/1
                 "(?m)name:(.|\\n)+?(^\\s{4}[\\w\\-:]+|\\n$|^\\s{2}-|^\\s{6}-)",
-                // Match the parts of a chart entry. Test: https://regex101.com/r/iqP5RJ/1
-                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$"
+                // Match the parts of a chart entry. Test: https://regex101.com/r/GgGbkM/1
+                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file|git):\\/\\/.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$"
             ],
             "datasourceTemplate": "helm"
         },

--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -109,8 +109,8 @@
                 "(?m)charts:(.|\\n)*?(^\\s{4}[\\w:]+|\\n$|^\\s{2}-)",
                 // Match a chart entry. Test: https://regex101.com/r/ibpxYd/1
                 "(?m)name:(.|\\n)+?(^\\s{4}[\\w\\-:]+|\\n$|^\\s{2}-|^\\s{6}-)",
-                // Match the parts of a chart entry. Test: https://regex101.com/r/2BhQd2/1
-                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file|git):\\/\\/.+?)[\"']?$"
+                // Match the parts of a chart entry. Test: https://regex101.com/r/tVVHYS/1
+                "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>(https|http|file):\\/\\/.+?)[\"']?$"
             ],
             "datasourceTemplate": "helm"
         },


### PR DESCRIPTION
resolves #140 

I'm not using uds-common's renovate config directly, I BORROWED some of the regex and was getting warnings/errors with oci helm charts in zarf packages because renovate's regex managers would match it for helm datasource first before doing docker datasource for oci helm charts.

Renovate issue & repo:
https://github.com/defenseunicorns/narwhal-delivery-zarf-package-eks-addons/issues/6
Specifically testing on branch `renovate-is-hard` 👆 

Renovate config used:
https://github.com/defenseunicorns/narwhal-delivery-zarf-package-eks-addons/blob/main/renovate.json5#L4-L6

Fixed regex manager:
https://github.com/defenseunicorns/narwhal-delivery-renovate-config/blob/main/zarfPackageGenericMatching.json5#L74-L101

Renovate logs from zarf package with oci helm chart that was throwing an error before these changes
```
      {
        "deps": [
          {
            "depName": "aws-node-termination-handler",
            "currentValue": "0.24.0",
            "datasource": "helm",
            "registryUrls": [
              "oci://public.ecr.aws/aws-ec2/helm/aws-node-termination-handler"
            ],
            "replaceString": "name: aws-node-termination-handler\n        namespace: aws-node-termination-handler\n        url: oci://public.ecr.aws/aws-ec2/helm/aws-node-termination-handler\n        version: 0.24.0",
            "updates": [],
            "packageName": "aws-node-termination-handler",
            "versioning": "helm",
            "warnings": [
              {
                "topic": "aws-node-termination-handler",
                "message": "Failed to look up helm package aws-node-termination-handler"
              }
            ]
          }
        ],
        "matchStrings": [
          "(?m)charts:(.|\\n)*?(^\\s{4}[\\w:]+|\\n$|^\\s{2}-)",
          "(?m)name:(.|\\n)+?(^\\s{4}[\\w\\-:]+|\\n$|^\\s{2}-|^\\s{6}-)",
          "(?m)name: [\"']?(?<depName>.+?)[\"']?$(.|\\n)*?url: [\"']?(?<registryUrl>.+?)[\"']?$(.|\\n)*?version: [\"']?(?<currentValue>.+?)[\"']?$"
        ],
        "matchStringsStrategy": "recursive",
        "datasourceTemplate": "helm",
        "packageFile": "packages/aws-node-termination-handler/common/zarf.yaml"
      },
```