### PR TITLE
chore: allow debug logs to continue through failure

### DIFF
--- a/.github/actions/debug-output/action.yaml
+++ b/.github/actions/debug-output/action.yaml
@@ -7,18 +7,18 @@ runs:
     - name: Print basic debug info for a k8s cluster
       run: |
         echo "::group::kubectl get all"
-        uds zarf tools kubectl get all -A | tee /tmp/debug-k-get-all.log
+        uds zarf tools kubectl get all -A || echo "failed" | tee /tmp/debug-k-get-all.log
         echo "::endgroup::"
         echo "::group::kubectl get pv,pvc"
-        uds zarf tools kubectl get pv,pvc -A | tee /tmp/debug-k-get-pv-pvc.log
+        uds zarf tools kubectl get pv,pvc -A || echo "failed" | tee /tmp/debug-k-get-pv-pvc.log
         echo "::endgroup::"
         echo "::group::kubectl get package"
-        uds zarf tools kubectl get package -A | tee /tmp/debug-k-get-package.log
+        uds zarf tools kubectl get package -A || echo "failed" | tee /tmp/debug-k-get-package.log
         echo "::endgroup::"
         echo "::group::kubectl get events"
-        uds zarf tools kubectl get events -A --sort-by='.lastTimestamp' | tee /tmp/debug-k-get-events.log
+        uds zarf tools kubectl get events -A --sort-by='.lastTimestamp' || echo "failed" | tee /tmp/debug-k-get-events.log
         echo "::endgroup::"
         echo "::group::kubectl describe nodes"
-        uds zarf tools kubectl describe nodes k3d-uds-server-0 | tee /tmp/debug-k-describe-node.log
+        uds zarf tools kubectl describe nodes k3d-uds-server-0 || echo "failed" | tee /tmp/debug-k-describe-node.log
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
This adds `|| echo "failed"` to the debug log action to continue in the event of failures looking things up - i.e. if pepr hasn't installed yet and there is no package CRD.