### PR TITLE
chore: upgrade uds cli-cli to v0.11.2

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,7 +11,7 @@ inputs:
   udsCliVersion:
     description: The uds-cli version to install
     # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    default: 0.10.4
+    default: 0.11.2
 
 runs:
   using: composite

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -23,7 +23,6 @@ runs:
     - name: Set UDS CLI Arch
       id: setUdsCliArch
       shell: bash
-#      run: INPUT=${{ runner.arch == 'X64' && 'amd64' || runner.arch }}; echo "::set-output name=arch::${INPUT,,}"
       run: INPUT=${{ runner.arch == 'X64' && 'amd64' || runner.arch }}; echo "ARCH=${INPUT,,}" >> "$GITHUB_OUTPUT"
 
     - name: Install UDS CLI

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,7 +11,7 @@ inputs:
   udsCliVersion:
     description: The uds-cli version to install
     # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-    default: 0.11.0
+    default: 0.10.4
 
 runs:
   using: composite


### PR DESCRIPTION
Upgrade uds-cli to v0.11.2 because of an issue pulling image layers with v0.11.1