### PR TITLE
feat: add an image override to the renovate config

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -109,6 +109,15 @@
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
             "extractVersionTemplate": "^v(?<version>.*)$"
         },
+        // Matches images where you need to override the image reference in a Helm Value (i.e. https://github.com/defenseunicorns/uds-capability-rook-ceph/blob/f190c32688e80ad72df6389bcb150b35d779d0f0/values/cluster-values.yaml#L3-L4)
+        {
+            "fileMatch": ["\\.*\\.ya?ml$"],
+            "matchStrings": [
+                // Test: https://regex101.com/r/k5ebjz/1
+                "# renovate: image=(?<depName>.*?)\\s*image:\\s.*:(?<currentValue>[^\\s\"]*)",
+            ],
+            "datasourceTemplate": "docker"
+        },
         // Matches individual images in a `zarf.yaml`'s `images:` section that are tagged with a version (allowing for # renovate overrides)
         {
             "fileMatch": [ "(^|/)zarf\\.ya?ml$" ],


### PR DESCRIPTION
This adds an image override to the renovate config (useful for `###ZARF_REGISTRY###` Helm values).