### PR TITLE
chore: fix commitlint workflow permissions

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -16,6 +16,7 @@ jobs:
     name: Validate PR Title
     permissions:
       pull-requests: read # Allows reading pull request metadata.
+      contents: read  # Allows pulling repo contents.
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This fixes the permissions on the common `commitlint` workflow (to allow it to run on private / internal repos while we develop new things)