### PR TITLE
chore: fix version matching for UDS packages

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -248,7 +248,9 @@
                 // Match the parts of a chart entry. Test: https://regex101.com/r/IFgEw0/1
                 "(?m)repository: [\"']?(?<depName>.+?)[\"']?$(.)*(\n.*){0,2}ref: [\"']?(?<currentValue>.+?)[\"']?$"
             ],
-            "datasourceTemplate": "docker"
+            "datasourceTemplate": "docker",
+            // Match versioning used on UDS packages. Test: https://regex101.com/r/BGkYHX/3
+            "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-uds\\.(?<build>\\d)(-.*?)?)?(.*?)?$"
         }
     ],
     "packageRules": [


### PR DESCRIPTION
This adds a version regex to the renovate for Zarf packages to match UDS package versioning schemes (as well as other semantic versions) - tested here:

- https://github.com/Racer159/uds-common/blob/d13629f5177feaf4257f8dcc5b6ea4a509077966/config/renovate.json5#L232C44-L234C129
- https://github.com/Racer159/uds-package-sonarqube/pull/17