### PR TITLE
chore: fix codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-/* @defenseunicorns/uds-core @defenseunicorns/swf @defenseunicorns/zarf @defenseunicorns/pepr @defenseunicorns/lula-dev @defenseunicorns/uds @defenseunicorns/leapfrogai
+* @defenseunicorns/uds-core @defenseunicorns/swf @defenseunicorns/zarf @defenseunicorns/pepr @defenseunicorns/lula-dev @defenseunicorns/uds @defenseunicorns/leapfrogai
 
 # Common Renovate Configuration (updates as soon as it hits `main`)
 /config/renovate.json5 @defenseunicorns/uds-core @defenseunicorns/swf @defenseunicorns/tech-leads
@@ -8,5 +8,5 @@
 /docs/uds-package-practices.md @defenseunicorns/tech-leads
 
 # Additional privileged files
-/CODEOWNERS @jeff-mccoy @austenbryan
-/LICENSE @jeff-mccoy @austenbryan
+/CODEOWNERS @jeff-mccoy @daveworth
+/LICENSE @jeff-mccoy @daveworth


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

/* only protects the top level files.

