### PR TITLE
fix: renovate typo token/password

### DIFF
--- a/.github/workflows/ci-docs-shim.yaml
+++ b/.github/workflows/ci-docs-shim.yaml
@@ -19,6 +19,7 @@ on:
       - LICENSE
       - CONTRIBUTING.md
       - SECURITY.md
+      - config/renovate.json5
 
 jobs:
   run-test:

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -21,6 +21,7 @@ on:
       - LICENSE
       - CONTRIBUTING.md
       - SECURITY.md
+      - config/renovate.json5
 
 concurrency:
   group: test-${{ github.ref }}

--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -47,7 +47,7 @@
             "hostType": "docker",
             "description": "Encrypted creds for ghcr.io, scoped to this Github org using: https://docs.renovatebot.com/getting-started/migrating-secrets/#migrate-your-secrets-in-encrypted-form",
             "username": "renovate",
-            "token": "{{ secrets.DEFENSEUNICORNS_PACKAGE_READ_PAT }}"
+            "password": "{{ secrets.DEFENSEUNICORNS_PACKAGE_READ_PAT }}"
         }
     ],
     "regexManagers": [


### PR DESCRIPTION
Based on https://github.com/renovatebot/renovate/discussions/22347 this should be password - failed typo/conflict fix.

Also filters out common renovate changes from the CI (using docs shim).