### PR TITLE
feat: add KEYCLOAK_GROUP var for create-doug-user task

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -57,7 +57,7 @@ tasks:
           --header "Authorization: Bearer ${KEYCLOAK_ADMIN_TOKEN}" \
           --data-raw '{
               "username": "doug",
-              "firstName": "doug",
+              "firstName": "Doug",
               "lastName": "Unicorn",
               "email": "doug@uds.dev",
               "attributes": {
@@ -89,7 +89,3 @@ tasks:
                   \"id\": \"${CONDITIONAL_OTP_ID}\",
                   \"requirement\": \"DISABLED\"
               }"
-  
-  - name: echo-variable
-    actions:
-      - cmd: echo ${KEYCLOAK_GROUP}

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -1,3 +1,6 @@
+variables:
+  - name: KEYCLOAK_GROUP
+
 tasks:
   - name: k3d-test-cluster
     inputs:
@@ -54,7 +57,7 @@ tasks:
           --header "Authorization: Bearer ${KEYCLOAK_ADMIN_TOKEN}" \
           --data-raw '{
               "username": "doug",
-              "firstName": "Doug",
+              "firstName": "doug",
               "lastName": "Unicorn",
               "email": "doug@uds.dev",
               "attributes": {
@@ -69,7 +72,10 @@ tasks:
                   "value": "unicorn123!@#UN",
                   "temporary": false
                 }
-              ]
+              ]'"${KEYCLOAK_GROUP:+,
+              \"groups\": [
+                \"${KEYCLOAK_GROUP}\"
+              ]}"'
           }'
 
           # Disable 2FA
@@ -83,3 +89,7 @@ tasks:
                   \"id\": \"${CONDITIONAL_OTP_ID}\",
                   \"requirement\": \"DISABLED\"
               }"
+  
+  - name: echo-variable
+    actions:
+      - cmd: echo ${KEYCLOAK_GROUP}


### PR DESCRIPTION
This PR introduces the ability to automatically assign the Doug user to a specific Keycloak group during the `create-doug-user` task. This is achieved through the use of an environment variable, KEYCLOAK_GROUP, which specifies the group path.

Example Usage:

Running the following command creates the Doug user and assigns them to the Admin group, which is nested under the parent UDS Core group:
`uds run setup:create-doug-user --set KEYCLOAK_GROUP="/UDS Core/Admin"`

Behavioral Changes:

If KEYCLOAK_GROUP is not set: The Doug user is created without any group assignment, adhering to the existing behavior.

If KEYCLOAK_GROUP is set to a valid group: The Doug user is created and assigned to the specified group. In the example above, Doug would be added to the Admin group under UDS Core.

If KEYCLOAK_GROUP is set to an invalid or non-existent group: The user creation process fails, preventing the creation of a user who would be assigned to a non-existent group.