### PR TITLE
fix: mandate yamllint at least 1.30.0 to guarantee features in use

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -7,7 +7,7 @@ tasks:
     description: Install linting tool dependencies
     actions:
       - description: Install yamllint via pip
-        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install yamllint
+        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install yamllint>=1.30.0
 
   - name: yaml
     description: Run YAML linting checks


### PR DESCRIPTION
Version 1.29.0 introduced something with the ignore filepaths. If using v1.28.0 or earlier you get the error `invalid config: ignore should contain file patterns`.

Anchors, in use in at least the uds-package-mattermost repo are not recognized in v1.29.0, hence setting v1.30.0 as the minimum allowed version.

As the code stood, having say version 1.26.0 installed satisfied the `pip install yamllint` command but `uds run lint:yaml` failed frustrating this end user.