### PR TITLE
fix: allow dependent bundle commands to be run on upgrade tests

### DIFF
--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -16,6 +16,7 @@ on:
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
   contents: read # Allows reading the content of the repository.
+  packages: read # Allows reading the content of the repository's packages.
   id-token: write
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ on:
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
   contents: read # Allows reading the content of the repository.
+  packages: read # Allows reading the content of the repository's packages.
   id-token: write
 
 jobs:

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -32,6 +32,10 @@ tasks:
         description: The architecture of the package to create
         default: ${UDS_ARCH}
 
+      dep_commands:
+        description: Additional commands to run inside the old repo to setup dependencies
+        default: ""
+
     actions:
       - task: utils:determine-repo
         with:
@@ -65,6 +69,9 @@ tasks:
             oci://${TARGET_REPO}/${PACKAGE_NAME}:${LATEST_VERSION} \
             --no-progress \
             -o ${{ .inputs.path }}
+
+          # Run any dependency commands (i.e. uds run dependencies:create)
+          sh -c "${{ .inputs.dep_commands }}"
 
           # Checks if the zarf package is registry1 and ARM
           if [ ${FLAVOR} != "registry1" ] || [ ${{ .inputs.architecture }} != "arm64" ]; then


### PR DESCRIPTION
This adds an input to allow dependency commands to run in the cloned repo prior to bundle create as needed in some repos (i.e. something needing `uds run dependencies:create`)