### PR TITLE
chore: use uds cli-vendored yq in badge verification task

### DIFF
--- a/tasks/badge.yaml
+++ b/tasks/badge.yaml
@@ -84,10 +84,10 @@ tasks:
           fi
 
           if [[ "${COMMON_ZARF}" == "true" ]]; then
-            NAMESPACE=$(yq '.components[].charts[].namespace' common/zarf.yaml | uniq)
+            NAMESPACE=$(uds zarf tools yq '.components[].charts[].namespace' common/zarf.yaml | uniq)
           else
             gh_warning "  ⚠️  There is no common zarf.yaml file"
-            NAMESPACE=$(yq '.components[].charts[].namespace' zarf.yaml | uniq)
+            NAMESPACE=$(uds zarf tools yq '.components[].charts[].namespace' zarf.yaml | uniq)
           fi
           gh_notice "  ℹ️  Namespace: $NAMESPACE"
 
@@ -305,7 +305,7 @@ tasks:
           ## Should expose all configuration (uds.dev CRs, additional Secrets/ConfigMaps, etc) through a Helm chart (ideally in a chart or charts directory).
 
           if [ "${COMMON_ZARF}" == "true" ]; then
-            COMMON_ZARF_MANIFEST_COUNT=$(cat common/zarf.yaml | yq '.components[] | select(.manifests != null) | length' | wc -l)
+            COMMON_ZARF_MANIFEST_COUNT=$(cat common/zarf.yaml | uds zarf tools yq '.components[] | select(.manifests != null) | length' | wc -l)
             if [ "$COMMON_ZARF_MANIFEST_COUNT" -gt 0 ]; then
               gh_error "  ❌ Manifests present in common/zarf.yaml"
             else
@@ -313,7 +313,7 @@ tasks:
             fi
           fi
 
-          MAIN_ZARF_MANIFEST_COUNT=$(cat zarf.yaml | yq '.components[] | select(.manifests != null) | length' | wc -l)
+          MAIN_ZARF_MANIFEST_COUNT=$(cat zarf.yaml | uds zarf tools yq '.components[] | select(.manifests != null) | length' | wc -l)
           if [ "$MAIN_ZARF_MANIFEST_COUNT" -gt 0 ]; then
             gh_error "  ❌ Manifests present in zarf.yaml"
           else
@@ -322,7 +322,7 @@ tasks:
 
           ## Should implement or allow for multiple flavors (ideally with common definitions in a common directory)
 
-          ZARF_COMPONENTS_FLAVOR_COUNT=$(cat zarf.yaml | yq '.components[] | select(.only.flavor != null) | length' | wc -l)
+          ZARF_COMPONENTS_FLAVOR_COUNT=$(cat zarf.yaml | uds zarf tools yq '.components[] | select(.only.flavor != null) | length' | wc -l)
           if [ "$ZARF_COMPONENTS_FLAVOR_COUNT" -eq 0 ]; then
             gh_error "  ❌ No flavors defined in zarf.yaml"
           else
@@ -351,8 +351,8 @@ tasks:
 
           # Must be consistently versioned across flavors - this can take many forms but flavors should differ in image bases/builds not application versions.
 
-          ZARF_PKG_VERSION=$(yq '.metadata.version' zarf.yaml | cut -d '-' -f1)
-          IMAGE_WITH_ZARF_VERSION_COUNT=$(cat zarf.yaml | yq '.components[].images' | grep -o "${ZARF_PKG_VERSION}" | wc -l)
+          ZARF_PKG_VERSION=$(uds zarf tools yq '.metadata.version' zarf.yaml | cut -d '-' -f1)
+          IMAGE_WITH_ZARF_VERSION_COUNT=$(cat zarf.yaml | uds zarf tools yq '.components[].images' | grep -o "${ZARF_PKG_VERSION}" | wc -l)
 
           if [ "$IMAGE_WITH_ZARF_VERSION_COUNT" -ge "$ZARF_COMPONENTS_FLAVOR_COUNT" ]; then
             gh_notice "  ✅ Version is consistent across flavors and package"


### PR DESCRIPTION
Uses UDS CLI-vendored `yq` to perform the badge verification task.