### PR TITLE
fix!: remove with.assessment_results from oscal tasks

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -62,7 +62,7 @@ jobs:
             /tmp/debug-*.log
             /tmp/uds-containerd-logs
             /tmp/k3d-uds-*.log
-            /tmp/oscal-assessment-results.yaml
+            oscal-assessment-results.yaml
 
       - uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
         if: always() && ${{ inputs.reports-path != '' }}

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -92,7 +92,7 @@ jobs:
             /tmp/debug-*.log
             /tmp/uds-containerd-logs
             /tmp/k3d-uds-*.log
-            /tmp/oscal-assessment-results.yaml
+            oscal-assessment-results.yaml
 
       - uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4.4.1
         if: always() && ${{ inputs.reports-path != '' }}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -75,8 +75,6 @@ tasks:
 
       - description: Validate OSCAL compliance
         task: compliance:validate
-        with:
-          assessment_results: /tmp/oscal-assessment-results.yaml
 
   - name: test-upgrade
     description: Test an upgrade from the latest released package to the current branch
@@ -85,16 +83,10 @@ tasks:
       - task: setup:k3d-test-cluster
       - task: deploy:test-bundle
       - task: compliance:validate
-        with:
-          assessment_results: /tmp/oscal-assessment-results.yaml
       - task: create-dev-package
       - task: create-deploy-test-bundle
       - task: compliance:validate
-        with:
-          assessment_results: /tmp/oscal-assessment-results.yaml
       - task: compliance:evaluate
-        with:
-          assessment_results: /tmp/oscal-assessment-results.yaml
 
   - name: publish-package
     description: Build and publish the packages


### PR DESCRIPTION
## Description

remove with.assessment_results: /tmp/oscal-assessment-results.yaml in oscal task calls

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
