### PR TITLE
chore: disable stale PR rebasing for renovate

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -10,10 +10,10 @@
     // Disable reviewers getting added by renovate to limit notification noise
     "reviewersFromCodeOwners": false,
     "timezone": "America/New_York",
-    "rebaseStalePrs": true,
     "dependencyDashboard": true,
     "dependencyDashboardTitle": "Renovate Dashboard 🤖",
     "rebaseWhen": "conflicted",
+    "rebaseStalePrs": false,
     "commitBodyTable": true,
     "suppressNotifications": ["prIgnoreNotification"],
     "pre-commit": {


### PR DESCRIPTION
## Description

We currently have a confusing combination of renovate options:
- `"rebaseWhen": "conflicted",`: Only rebases if a PR has conflicts
- `"rebaseStalePrs": true`: Sets `rebaseWhen` to `behind-base-branch` overriding ^

Imo it makes more sense to be less aggressive with rebasing in the base config and allow individual repos to override this. If this PR is not accepted as it stands we should still resolve the confusion around these two options (align them).

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
