### PR TITLE
fix: modified jq command in badge.yaml

### DIFF
--- a/tasks/badge.yaml
+++ b/tasks/badge.yaml
@@ -270,7 +270,7 @@ tasks:
 
               # Must deploy and operate successfully with Istio injection enabled in the namespace.
               POD_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" --no-headers | wc -l)
-              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
+              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
 
               if [ "$POD_COUNT" -ne "$POD_SIDECAR_COUNT" ]; then
                   gh_error "  ❌ Not all pods have the istio sidecar"


### PR DESCRIPTION
## Description

To get the correct count of pods with the istio-proxy sidecar, I modified the jq command to output just one line per matching pod.

Fixes #281 

...

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
