### PR TITLE
fix: modified jq command

### DIFF
--- a/tasks/badge.yaml
+++ b/tasks/badge.yaml
@@ -270,7 +270,7 @@ tasks:
 
               # Must deploy and operate successfully with Istio injection enabled in the namespace.
               POD_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" --no-headers | wc -l)
-              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
+              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o yaml | uds zarf tools yq eval '[.items[] | select(.spec.containers[].name == "istio-proxy")] | length' -)
 
               if [ "$POD_COUNT" -ne "$POD_SIDECAR_COUNT" ]; then
                   gh_error "  ❌ Not all pods have the istio sidecar"

--- a/tasks/badge.yaml
+++ b/tasks/badge.yaml
@@ -187,7 +187,7 @@ tasks:
           # Must be consistently versioned across flavors - this can take many forms but flavors should differ in image bases/builds not application versions.
 
           ZARF_PKG_VERSION=$(uds zarf tools yq '.metadata.version' "${PACKAGE_DIR}/zarf.yaml" | cut -d '-' -f1)
-          IMAGE_WITH_ZARF_VERSION_COUNT=$(uds zarf tools kubectl get pods -n "cert-manager" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
+          IMAGE_WITH_ZARF_VERSION_COUNT=$(uds zarf tools yq '.components[].images[]' "${PACKAGE_DIR}/zarf.yaml" | grep -o "${ZARF_PKG_VERSION}" | wc -l)
 
           if [ "$IMAGE_WITH_ZARF_VERSION_COUNT" -ge "$ZARF_COMPONENTS_FLAVOR_COUNT" ]; then
               gh_notice "  ✅ Version is consistent across flavors and package"
@@ -270,7 +270,7 @@ tasks:
 
               # Must deploy and operate successfully with Istio injection enabled in the namespace.
               POD_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" --no-headers | wc -l)
-              PDO_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
+              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
 
               if [ "$POD_COUNT" -ne "$POD_SIDECAR_COUNT" ]; then
                   gh_error "  ❌ Not all pods have the istio sidecar"

--- a/tasks/badge.yaml
+++ b/tasks/badge.yaml
@@ -187,7 +187,7 @@ tasks:
           # Must be consistently versioned across flavors - this can take many forms but flavors should differ in image bases/builds not application versions.
 
           ZARF_PKG_VERSION=$(uds zarf tools yq '.metadata.version' "${PACKAGE_DIR}/zarf.yaml" | cut -d '-' -f1)
-          IMAGE_WITH_ZARF_VERSION_COUNT=$(uds zarf tools yq '.components[].images[]' "${PACKAGE_DIR}/zarf.yaml" | grep -o "${ZARF_PKG_VERSION}" | wc -l)
+          IMAGE_WITH_ZARF_VERSION_COUNT=$(uds zarf tools kubectl get pods -n "cert-manager" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
 
           if [ "$IMAGE_WITH_ZARF_VERSION_COUNT" -ge "$ZARF_COMPONENTS_FLAVOR_COUNT" ]; then
               gh_notice "  ✅ Version is consistent across flavors and package"
@@ -270,7 +270,7 @@ tasks:
 
               # Must deploy and operate successfully with Istio injection enabled in the namespace.
               POD_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" --no-headers | wc -l)
-              POD_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
+              PDO_SIDECAR_COUNT=$(uds zarf tools kubectl get pods -n "${NAMESPACE}" -o json | jq -c '.items[] | select(.spec.containers[].name == "istio-proxy")' | wc -l)
 
               if [ "$POD_COUNT" -ne "$POD_SIDECAR_COUNT" ]; then
                   gh_error "  ❌ Not all pods have the istio sidecar"


### PR DESCRIPTION
## Description

To get the correct count of pods with the istio-proxy sidecar, I modified the jq command to output just one line per matching pod.

Fixes #281

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
