### PR TITLE
chore: have addlicense ignore gitignored files

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -144,10 +144,15 @@ tasks:
           linux: bash
         cmd: |
           ignore_flags=()
-          for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
-            ignore_flags+=("-ignore" "$line")
-          done
-          "$HOME/go/bin/addlicense" -l "AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial" -check -s=only -v -c "Defense Unicorns" ${ignore_flags[@]} .
+          while IFS= read -r line; do
+            # Skip comments and empty lines
+            [ -z "$line" ] || [[ "$line" =~ ^# ]] && continue
+            # Add the line to ignore_flags array with quotes around it
+            ignore_flags+=("-ignore" "\"$line\"")
+          done < .gitignore
+
+          # Construct the command as a string
+          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -check -s=only -v -c \"Defense Unicorns\" ${ignore_flags[@]} . 2>/dev/null"
 
   - name: fix-license
     description: Add the SPDX license identifier to source files
@@ -157,7 +162,12 @@ tasks:
           linux: bash
         cmd: |
           ignore_flags=()
-          for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
-            ignore_flags+=("-ignore" "$line")
-          done
-          "$HOME/go/bin/addlicense" -l "AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial" -s=only -v -c "Defense Unicorns" ${ignore_flags[@]} .
+          while IFS= read -r line; do
+            # Skip comments and empty lines
+            [ -z "$line" ] || [[ "$line" =~ ^# ]] && continue
+            # Add the line to ignore_flags array with quotes around it
+            ignore_flags+=("-ignore" "\"$line\"")
+          done < .gitignore
+
+          # Construct the command as a string
+          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -s=only -v -c \"Defense Unicorns\" ${ignore_flags[@]} . 2>/dev/null"

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -139,19 +139,25 @@ tasks:
   - name: license
     description: Lint for the SPDX license identifier being in source files
     actions:
-      - cmd: |
-          ignore_flags=""
+      - shell:
+          darwin: bash
+          linux: bash
+        cmd: |
+          ignore_flags=()
           for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
-            ignore_flags="$ignore_flags -ignore \"$line\""
+            ignore_flags+=("-ignore" "$line")
           done
-          "$HOME/go/bin/addlicense" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -check -s=only -v -c 'Defense Unicorns' $ignore_flags .
+          "$HOME/go/bin/addlicense" -l "AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial" -check -s=only -v -c "Defense Unicorns" ${ignore_flags[@]} .
 
   - name: fix-license
     description: Add the SPDX license identifier to source files
     actions:
-      - cmd: |
-          ignore_flags=""
+      - shell:
+          darwin: bash
+          linux: bash
+        cmd: |
+          ignore_flags=()
           for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
-            ignore_flags="$ignore_flags -ignore \"$line\""
+            ignore_flags+=("-ignore" "$line")
           done
-          "$HOME/go/bin/addlicense" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -s=only -v -c 'Defense Unicorns' $ignore_flags .
+          "$HOME/go/bin/addlicense" -l "AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial" -s=only -v -c "Defense Unicorns" ${ignore_flags[@]} .

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -152,7 +152,7 @@ tasks:
           done < .gitignore
 
           # Construct the command as a string
-          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -check -s=only -v -c \"Defense Unicorns\" ${ignore_flags[@]} . 2>/dev/null"
+          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -check -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"
 
   - name: fix-license
     description: Add the SPDX license identifier to source files
@@ -170,4 +170,4 @@ tasks:
           done < .gitignore
 
           # Construct the command as a string
-          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -s=only -v -c \"Defense Unicorns\" ${ignore_flags[@]} . 2>/dev/null"
+          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -139,9 +139,19 @@ tasks:
   - name: license
     description: Lint for the SPDX license identifier being in source files
     actions:
-      - cmd: "\"$HOME/go/bin/addlicense\" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -check -s=only -v -c 'Defense Unicorns' ."
+      - cmd: |
+          ignore_flags=""
+          for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
+            ignore_flags="$ignore_flags -ignore \"$line\""
+          done
+          "$HOME/go/bin/addlicense" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -check -s=only -v -c 'Defense Unicorns' $ignore_flags .
 
   - name: fix-license
     description: Add the SPDX license identifier to source files
     actions:
-      - cmd: "\"$HOME/go/bin/addlicense\" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -s=only -v -c 'Defense Unicorns' ."
+      - cmd: |
+          ignore_flags=""
+          for line in $(grep -v '^#' .gitignore | grep -v '^$'); do
+            ignore_flags="$ignore_flags -ignore \"$line\""
+          done
+          "$HOME/go/bin/addlicense" -l 'AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial' -s=only -v -c 'Defense Unicorns' $ignore_flags .


### PR DESCRIPTION
## Description

Adds a short script to add `-ignore` flags for each line in gitignore that is not a comment/empty.

Caveat to this: `addlicense` does not behave exactly the same as `.gitignore`, for example a`folder` in the gitignore file will ignore that entire folder. With the addlicense command it must be `folder/**`. May necessitate some changes 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
