### PR TITLE
fix: upgrade test not cloning in private repos

### DIFF
--- a/.github/actions/test-flavor/action.yaml
+++ b/.github/actions/test-flavor/action.yaml
@@ -24,7 +24,7 @@ runs:
       id: set-required
       run: |
         # Check if any tag exists
-        TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")
+        TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
 
         if [ -z "$TAG" ]; then
           echo "No Git tags found. Skipping step."

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
 
       - name: Install UDS CLI
         uses: defenseunicorns/setup-uds@b987a32bac3baeb67bfb08f5e1544e2f9076ee8a # v1.0.0

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -56,7 +56,7 @@ tasks:
           mkdir upgrade-test
 
           shopt -s extglob dotglob
-          mv !(upgrade-test) upgrade-test
+          cp -r !(upgrade-test) upgrade-test
           shopt -u dotglob
 
       - description: Create test bundle of last tag
@@ -94,7 +94,6 @@ tasks:
               --no-progress \
               ${{ .inputs.options }}
 
-            mkdir -p ../${{ .inputs.bundle_path }}
             mv "${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${PREVIOUS_BUNDLE_VERSION}.tar.zst" "../${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${BUNDLE_VERSION}.tar.zst"
           else
             echo "::warning::⚠️ Registry1 bundles cannot be made for 'arm64'"

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -56,7 +56,7 @@ tasks:
           mv !(upgrade-test) upgrade-test
           shopt -u dotglob
 
-      - description: Create test bundle
+      - description: Create test bundle of last tag
         shell:
           linux: bash
           darwin: bash

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -49,6 +49,9 @@ tasks:
         cmd: rm -rf upgrade-test
 
       - description: Copy repo into the upgrade-test folder
+        shell:
+          linux: bash
+          darwin: bash
         cmd: |
           mkdir upgrade-test
 
@@ -63,7 +66,7 @@ tasks:
         dir: upgrade-test
         cmd: |
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
-          TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")
+          TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
           git checkout "$TAG"
 
           # VARIABLES

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -70,7 +70,7 @@ tasks:
           git checkout "$TAG"
 
           # VARIABLES
-          PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | yq .metadata.name)
+          PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -45,22 +45,26 @@ tasks:
         with:
           team: ${{.inputs.team}}
 
-      - description: Remove cloned repo
+      - description: Remove copied repo
         cmd: rm -rf upgrade-test
 
-      - description: Fetch the most recent tags
-        cmd: git fetch --tags
+      - description: Copy repo into the upgrade-test folder
+        cmd: |
+          mkdir upgrade-test
 
-      - description: Clone latest tag
-        cmd: git clone --depth 1 --branch "$(git describe --tags "$(git rev-list --tags --max-count=1)")" "$(git remote get-url origin)" upgrade-test
+          shopt -s extglob dotglob
+          mv !(upgrade-test) upgrade-test
+          shopt -u dotglob
 
       - description: Create test bundle
         shell:
           linux: bash
           darwin: bash
+        dir: upgrade-test
         cmd: |
-          BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
-          cd upgrade-test || exit
+          BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
+          TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")
+          git checkout "$TAG"
 
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | yq .metadata.name)
@@ -93,5 +97,4 @@ tasks:
             exit 1
           fi
 
-          cd ..
           rm -rf upgrade-test

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -94,7 +94,8 @@ tasks:
               --no-progress \
               ${{ .inputs.options }}
 
-            mv "${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${PREVIOUS_BUNDLE_VERSION}.tar.zst" "../bundle/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${BUNDLE_VERSION}.tar.zst"
+            mkdir -p ../${{ .inputs.bundle_path }}
+            mv "${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${PREVIOUS_BUNDLE_VERSION}.tar.zst" "../${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${BUNDLE_VERSION}.tar.zst"
           else
             echo "::warning::⚠️ Registry1 bundles cannot be made for 'arm64'"
             exit 1

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -97,4 +97,5 @@ tasks:
             exit 1
           fi
 
-          rm -rf upgrade-test
+      - description: Remove the upgrade-test folder
+        cmd: rm -rf upgrade-test


### PR DESCRIPTION
## Description

This fixes the upgrade tests for private repos by no longer requiring auth

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
