### PR TITLE
fix: lint:deps producing unwanted file

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -10,7 +10,7 @@ tasks:
     description: Install linting tool dependencies
     actions:
       - description: Install yamllint via pip
-        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install yamllint>=1.30.0
+        cmd: CMD=pip && which $CMD || CMD=pip3 && $CMD install "yamllint>=1.30.0"
       - description: Install addlicense via go
         # renovate: datasource=github-tags depName=google/addlicense versioning=semver
         cmd: GOPATH="$HOME/go" go install github.com/google/addlicense@v1.1.1


### PR DESCRIPTION
## Description
Was getting a random `=1.30.0` file when running lint:deps locally.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
