### PR TITLE
chore: adds check for addlicense

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -143,12 +143,14 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
-          if command -v addlicense &> /dev/null; then
-            echo "addlicense is installed"
+          # check for addlicense bin
+          if command -v addlicense &> /dev/null || [ -x "$HOME/go/bin/addlicense" ]; then
+              echo "addlicense installed"
           else
-            echo "Error: addlicense is not installed" >&2
-            exit 1
+              echo "Error: addlicense is not installed" >&2
+              exit 1
           fi
+
           ignore_flags=()
           while IFS= read -r line; do
             # Skip comments and empty lines
@@ -167,12 +169,14 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
-          if command -v addlicense &> /dev/null; then
-            echo "addlicense is installed"
+          # check for addlicense bin
+          if command -v addlicense &> /dev/null || [ -x "$HOME/go/bin/addlicense" ]; then
+              echo "addlicense installed"
           else
-            echo "Error: addlicense is not installed" >&2
-            exit 1
+              echo "Error: addlicense is not installed" >&2
+              exit 1
           fi
+
           ignore_flags=()
           while IFS= read -r line; do
             # Skip comments and empty lines

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -143,6 +143,11 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
+          if command -v addlicense &> /dev/null; then
+            echo "addlicense is installed"
+          else
+            echo "addlicense is not installed"
+          fi
           ignore_flags=()
           while IFS= read -r line; do
             # Skip comments and empty lines
@@ -161,6 +166,11 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
+          if command -v addlicense &> /dev/null; then
+            echo "addlicense is installed"
+          else
+            echo "addlicense is not installed"
+          fi
           ignore_flags=()
           while IFS= read -r line; do
             # Skip comments and empty lines

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -144,10 +144,10 @@ tasks:
           linux: bash
         cmd: |
           # check for addlicense bin
-          if command -v addlicense &> /dev/null || [ -x "$HOME/go/bin/addlicense" ]; then
-              echo "addlicense installed"
+          if [ -x "$HOME/go/bin/addlicense" ]; then
+              echo "addlicense installed in $HOME/go/bin"
           else
-              echo "Error: addlicense is not installed" >&2
+              echo "Error: addlicense is not installed in $HOME/go/bin" >&2
               exit 1
           fi
 

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -170,10 +170,10 @@ tasks:
           linux: bash
         cmd: |
           # check for addlicense bin
-          if command -v addlicense &> /dev/null || [ -x "$HOME/go/bin/addlicense" ]; then
-              echo "addlicense installed"
+          if [ -x "$HOME/go/bin/addlicense" ]; then
+              echo "addlicense installed in $HOME/go/bin"
           else
-              echo "Error: addlicense is not installed" >&2
+              echo "Error: addlicense is not installed in $HOME/go/bin" >&2
               exit 1
           fi
 

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -146,7 +146,8 @@ tasks:
           if command -v addlicense &> /dev/null; then
             echo "addlicense is installed"
           else
-            echo "addlicense is not installed"
+            echo "Error: addlicense is not installed" >&2
+            exit 1
           fi
           ignore_flags=()
           while IFS= read -r line; do
@@ -169,7 +170,8 @@ tasks:
           if command -v addlicense &> /dev/null; then
             echo "addlicense is installed"
           else
-            echo "addlicense is not installed"
+            echo "Error: addlicense is not installed" >&2
+            exit 1
           fi
           ignore_flags=()
           while IFS= read -r line; do


### PR DESCRIPTION
## Description

Adds a check for the `addlicense` binary before running the `license` and `fix-license` tasks
