### PR TITLE
fix: timeout too short

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -19,10 +19,14 @@ on:
         type: string
         description: The name prefix for upload test reports
         default: playwright-report
+      timeout:
+        type: number
+        default: 30
 
 jobs:
   run:
     runs-on: ${{ inputs.runsOn }}
+    timeout-minutes: ${{ inputs.timeout }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   run:
     runs-on: ${{ inputs.runsOn }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     if: contains(inputs.upgrade-flavors, inputs.flavor) || inputs.type == 'install'
 
     steps:

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -15,6 +15,9 @@ on:
       flavor:
         required: true
         type: string
+      timeout:
+        type: number
+        default: 20
       type:
         required: true
         type: string
@@ -40,7 +43,7 @@ permissions:
 jobs:
   run:
     runs-on: ${{ inputs.runsOn }}
-    timeout-minutes: 25
+    timeout-minutes: ${{ inputs.timeout }}
     if: contains(inputs.upgrade-flavors, inputs.flavor) || inputs.type == 'install'
 
     steps:


### PR DESCRIPTION
sometimes jobs take way too long and can cause/border on causing the job to cancel, an extra 5 minutes should give us the time needed https://github.com/defenseunicorns/uds-package-defectdojo/actions/runs/11357681356/job/31590966054?pr=8#step:4:1