### PR TITLE
Adding contributor location sanity checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache/
 .idea/
+.vscode/
 build/
 .DS_Store
 *.tar.zst

--- a/docs/uds-packages/guide.md
+++ b/docs/uds-packages/guide.md
@@ -6,7 +6,7 @@ This guide is intended for developers integrating applications with UDS (Unicorn
 
 Integrating a Package fundamentally means:
 1. Creating a repository `uds-package-<name>` from [uds-package-template](https://github.com/defenseunicorns/uds-package-template)
-2. Integrating the upstream helm chart as a zarf package `zarf.yaml` to build a declarative OCI artifact
+2. Integrating the upstream Helm chart as a zarf package `zarf.yaml` to build a declarative OCI artifact
 3. Adding a UDS package Custom Resource `uds-package.yaml` to integrate with UDS Core via Pepr
 4. Build a 'zero CVE' package by replacing images with a `*-unicorn` flavored image
 
@@ -15,6 +15,7 @@ Integrating a Package fundamentally means:
 - UDS generally assumes applications are containerized and can be deployed via Kubernetes. (exceptions are possible, but rare, and require additional work e.g. KubeVirt)
 - The integrator (you) should have access to the application image and deployment code.
 - The "App" should have a compatible license for UDS integration (Apache 2.0 or similar) [see Licensing Considerations](#licensing-considerations).
+- The "App" should have an available Helm chart which can be used for the Zarf package. If it does not have one, notify the Airgap App Store team before proceeding further.
 
 ### Licensing Considerations
 
@@ -37,9 +38,16 @@ Before beginning the integration process, familiarize yourself with the followin
 
 When integrating an application with UDS, consider the following requirements and suggestions:
 
-### Step 1 - Zarf Package
+### Step 1 - Sanity Check the Codebase
 
-Your goal is to bundle the upstream helm chart and images into a single Zarf package, defined in a `zarf.yaml`
+Because one of the main goals of the Airgap App Store is to provide a trusted repository of vetted, packaged apps for National Security missions, we need to ensure these packages meet certain requirements. These packages should not be obviously malware, or maintained entirely or in majority by or in a foreign or agressor nation/state.
+
+- [ ] Using your best judgment, run a Google search against the repository name and look for signs that it may be compromised or otherwise untrustworthy.
+- [ ] Validate the contributors to the repository by entering the repository into [OSS Insight](https://ossinsight.io) and checking the `People` tab to see where the majority of contributions came from. If you see significant contributions from suspicious locations, notify the Airgap App Store team before proceeding with further integration work. For example, [Harbor](https://ossinsight.io/analyze/goharbor/harbor#people) has an overwhelming number of contributions originating from within China.
+
+### Step 2 - Zarf Package
+
+Your goal is to bundle the upstream Helm chart and images into a single Zarf package, defined in a `zarf.yaml`
 
 *reminder https://docs.zarf.dev*
 
@@ -52,7 +60,7 @@ Your goal is to bundle the upstream helm chart and images into a single Zarf pac
 #### Checkout
 Your repository has a `zarf.yaml`, you can build a single artifact with `uds zarf package create`, and deploy it to a [k3d-core-dev-slim cluster](https://github.com/defenseunicorns/uds-core?tab=readme-ov-file#uds-package-development) using `uds zarf package deploy`
 
-### Step 2 - UDS Package
+### Step 3 - UDS Package
 
 Your goal is to integrate the Zarf package application with [UDS Core](https://github.com/defenseunicorns/uds-core), using `uds-package.yaml` custom resource.
 
@@ -61,7 +69,7 @@ Your goal is to integrate the Zarf package application with [UDS Core](https://g
 - [ ] [UDS Package Practices](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/requirements/uds-package-requirements.md) provides an extensive list of best practices, considerations, and tasks for a package to be "Made for UDS"
 
 #### Checkout
-Your repository has a `uds-package.yaml` manifest added to the appropriate helm chart and you can deploy to a K3d Core Dev Slim cluster, via zarf package.
+Your repository has a `uds-package.yaml` manifest added to the appropriate Helm chart and you can deploy to a K3d Core Dev Slim cluster, via zarf package.
 
 ## Examples
 


### PR DESCRIPTION
Adding some guidelines around basic smell-testing of apps and their repositories before proceeding with integration work. This includes cursory searches to see if the repos are known dirty for any reason, and validating the contributor/maintainer geolocations to see if there are overwhelming foreign influences.