### PR TITLE
feat(templates): add support for a templates directory

### DIFF
--- a/docs/uds-packages/guidelines/oscal-guidelines.md
+++ b/docs/uds-packages/guidelines/oscal-guidelines.md
@@ -14,9 +14,9 @@ Gold packages will include a baseline set of [NIST 800-53 controls](https://csrc
 - AU-12
 - SC-13
 
-This command will generate an `oscal-component.yaml` file for a package that implements these controls. Once generated you can add specific responses to the controls.
+This command will template an `oscal-component.yaml` file for a package that implements these controls. Once generated you can add specific responses to the controls.
 ```
-lula generate component -c https://raw.githubusercontent.com/GSA/fedramp-automation/refs/tags/fedramp-2.0.0-oscal-1.0.4/dist/content/rev5/baselines/json/FedRAMP_rev5_MODERATE-baseline-resolved-profile_catalog.json --framework il4 --requirements ac-6.9,au-2,au-3,au-3.1,au-8,au-12,sc-13 --remarks assessment-objective -o oscal-component.yaml --component 'app-name'
+lula tools template -f https://raw.githubusercontent.com/defenseunicorns/uds-common/refs/heads/main/templates/component.yaml --set .const.component.title='app name' --set .const.component.description='description of the application' -o oscal-component.yaml
 ```
 
 > [!TIP]

--- a/templates/component.yaml
+++ b/templates/component.yaml
@@ -1,0 +1,90 @@
+component-definition:
+  components:
+    - control-implementations:
+        - description: Control Implementation Description
+          implemented-requirements:
+            - control-id: ac-6.9
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |-
+                ASSESSMENT-OBJECTIVE:
+                the execution of privileged functions is logged.
+              uuid: {{ uuid }}
+            - control-id: au-12
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |
+                ASSESSMENT-OBJECTIVE:
+                AU-12a. audit record generation capability for the event types the system is capable of auditing (defined in AU-02_ODP[01]) is provided by [Assignment: organization-defined system components];
+                AU-12b.  [Assignment: organization-defined personnel or roles] is/are allowed to select the event types that are to be logged by specific components of the system;
+                AU-12c. audit records for the event types defined in AU-02_ODP[02] that include the audit record content defined in AU-03 are generated.
+              uuid: {{ uuid }}
+            - control-id: au-2
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |
+                ASSESSMENT-OBJECTIVE:
+                AU-02a.  [Assignment: organization-defined event types] that the system is capable of logging are identified in support of the audit logging function;
+                AU-02b. the event logging function is coordinated with other organizational entities requiring audit-related information to guide and inform the selection criteria for events to be logged;
+                AU-02c.
+                	AU-02c.[01]  [Assignment: organization-defined event types (subset of AU-02_ODP[01])] are specified for logging within the system;
+                	AU-02c.[02] the specified event types are logged within the system [Assignment: organization-defined frequency or situation];
+                AU-02d. a rationale is provided for why the event types selected for logging are deemed to be adequate to support after-the-fact investigations of incidents;
+                AU-02e. the event types selected for logging are reviewed and updated [Assignment: organization-defined frequency].
+              uuid: {{ uuid }}
+            - control-id: au-3
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |
+                ASSESSMENT-OBJECTIVE:
+                AU-03a. audit records contain information that establishes what type of event occurred;
+                AU-03b. audit records contain information that establishes when the event occurred;
+                AU-03c. audit records contain information that establishes where the event occurred;
+                AU-03d. audit records contain information that establishes the source of the event;
+                AU-03e. audit records contain information that establishes the outcome of the event;
+                AU-03f. audit records contain information that establishes the identity of any individuals, subjects, or objects/entities associated with the event.
+              uuid: {{ uuid }}
+            - control-id: au-3.1
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |-
+                ASSESSMENT-OBJECTIVE:
+                generated audit records contain the following [Assignment: organization-defined additional information].
+              uuid: {{ uuid }}
+            - control-id: au-8
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |
+                ASSESSMENT-OBJECTIVE:
+                AU-08a. internal system clocks are used to generate timestamps for audit records;
+                AU-08b. timestamps are recorded for audit records that meet [Assignment: organization-defined granularity of time measurement] and that use Coordinated Universal Time, have a fixed local time offset from Coordinated Universal Time, or include the local time offset as part of the timestamp.
+              uuid: {{ uuid }}
+            - control-id: sc-13
+              description: <how the specified control may be implemented if the containing component or capability is instantiated in a system security plan>
+              remarks: |
+                ASSESSMENT-OBJECTIVE:
+                SC-13a.  [Assignment: organization-defined cryptographic uses] are identified;
+                SC-13b.  [Assignment: organization-defined types of cryptography] for each specified cryptographic use (defined in SC-13_ODP[01]) are implemented.
+              uuid: {{ uuid }}
+          props:
+            - name: generation
+              ns: https://docs.lula.dev/oscal/ns
+              value: lula generate component --catalog-source https://raw.githubusercontent.com/GSA/fedramp-automation/refs/tags/fedramp-2.0.0-oscal-1.0.4/dist/content/rev5/baselines/json/FedRAMP_rev5_MODERATE-baseline-resolved-profile_catalog.json --component '{{ .const.component.title }}' --requirements ac-6.9,au-2,au-3,au-3.1,au-8,au-12,sc-13 --remarks assessment-objective --framework il4
+            - name: framework
+              ns: https://docs.lula.dev/oscal/ns
+              value: il4
+          source: https://raw.githubusercontent.com/GSA/fedramp-automation/refs/tags/fedramp-2.0.0-oscal-1.0.4/dist/content/rev5/baselines/json/FedRAMP_rev5_MODERATE-baseline-resolved-profile_catalog.json
+          uuid: cfc9d077-62f0-51d8-a1c6-a733c70ef24e
+      description: {{ .const.component.description }}
+      title: {{ .const.component.title }}
+      type: software
+      uuid: {{ uuid }}
+  metadata:
+    last-modified: {{ timestamp }}
+    oscal-version: 1.1.2
+    parties:
+      - links:
+          - href: https://defenseunicorns.com/
+            rel: website
+        name: Defense Unicorns
+        type: organization
+        uuid: bf31d461-82af-529a-8bdf-09aa488e5b7e
+    published: {{ timestamp }}
+    remarks: Lula Generated Component Definition
+    title: {{ .const.component.title }}
+    version: 0.0.1
+  uuid: {{ uuid }}


### PR DESCRIPTION
## Description

In response to resolving #252 - this adds a `templates` directory to allow for more provenant OSCAL creation through centralized OSCAL templating vs more generic generation.

Lula allows the templating artifact to be a remote (network) location - test this locally with:
```bash
lula tools template -f https://raw.githubusercontent.com/defenseunicorns/uds-common/e6a11cd49007967350984ddd5efd5130cfae4803/templates/component.yaml --set .const.component.title='app-name' --set .const.component.description='description of t
he application' -o oscal-component.yaml
```

There is built in support for `uuid` and `timestamp` generation and this process both meets parity with the previous generation process as well as allows us to centralize entries such as `metadata.parties` to ensure consistency across the organization. 


## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
