### PR TITLE
docs: chainguard images docs

### DIFF
--- a/docs/uds-packages/guidelines/hardened-images.md
+++ b/docs/uds-packages/guidelines/hardened-images.md
@@ -9,4 +9,4 @@ Verify that your image does not exist in [Chainguard](https://images.chainguard.
 -  In the form, select `Area: Images` and `Type: Request a new Chainguard Image`.
 -  Fill out the rest of the form as needed.
 -  Once the request has been submitted, add the image information into this [Google Doc](https://docs.google.com/spreadsheets/d/1K59U8ZlAClDa5Xv7I-49OUj86BB18y53afn5_I9uRYI/edit?gid=0#gid=0).
--  Post in the Chainguard Images channel if you have access. This is a channel that is intentionally kept private, if you do not have access to this channel, you can work with a representative on your team, who can post on your behalf. If you do not know who your team representative is, please post in the `#airgap-appstore-apps` slack channel.
+-  Post in the `#ext-defenseunicorns-chainguard` channel if you have access. This is a channel that is intentionally kept private, if you do not have access to this channel, you can work with a representative on your team, who can post on your behalf. If you do not know who your team representative is, please post in the `#airgap-appstore-apps` slack channel.

--- a/docs/uds-packages/guidelines/hardened-images.md
+++ b/docs/uds-packages/guidelines/hardened-images.md
@@ -1,0 +1,12 @@
+# Requesting Chainguard Images
+
+Verify that your image does not exist in [Chainguard](https://images.chainguard.dev/). If it does not exist, follow the below steps.
+
+-  Go to: [https://support.chainguard.dev/hc/en-us](https://support.chainguard.dev/hc/en-us)
+-  On the top right corner, click `submit a request`.
+-  When it prompts you to login, select `Continue with SSO`.
+-  Select `Continue with Google`, login with your Unicorn Account.
+-  In the form, select `Area: Images` and `Type: Request a new Chainguard Image`.
+-  Fill out the rest of the form as needed.
+-  Once the request has been submitted, add the image information into this [Google Doc](https://docs.google.com/spreadsheets/d/1K59U8ZlAClDa5Xv7I-49OUj86BB18y53afn5_I9uRYI/edit?gid=0#gid=0).
+-  Post in the Chainguard Images channel if you have access. This is a channel that is intentionally kept private, if you do not have access to this channel, you can work with a representative on your team, who can post on your behalf. If you do not know who your team representative is, please post in the `#airgap-appstore-apps` slack channel.


### PR DESCRIPTION
## Description

- Added a doc to `docs/uds-packages/guidelines/hardened-images.md`, that explains how to request a Chainguard Image
- References: https://github.com/defenseunicorns/uds-common/issues/234
## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
