### PR TITLE
fix: don't fail if `zarf.yaml` not found in tag

### DIFF
--- a/.github/actions/test-flavor/action.yaml
+++ b/.github/actions/test-flavor/action.yaml
@@ -35,5 +35,5 @@ runs:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set output
-        echo "upgrade-flavors=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, -)" >> "$GITHUB_OUTPUT"
+        echo "upgrade-flavors=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -38,7 +38,7 @@ test:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set UPGRADE_FLAVORS
-        UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, -)
+        UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "") 
 
         # change back to the commit branch for the rest of the job
         git checkout "$CI_COMMIT_BRANCH"

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -38,7 +38,7 @@ test:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set UPGRADE_FLAVORS
-        UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "") 
+        UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "")
 
         # change back to the commit branch for the rest of the job
         git checkout "$CI_COMMIT_BRANCH"

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -41,7 +41,7 @@ test:
         UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "")
 
         # change back to the commit branch for the rest of the job
-        git checkout "$CI_COMMIT_BRANCH"
+        git checkout -
       fi
 
     - |


### PR DESCRIPTION
## Description

Don't fail if the tag doesn't have a zarf.yaml when doing upgrade flavor check.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
