### PR TITLE
feat: allow alternate paths for the check flavor zarf.yaml

### DIFF
--- a/.github/actions/test-flavor/action.yaml
+++ b/.github/actions/test-flavor/action.yaml
@@ -10,7 +10,7 @@ outputs:
     description: Indicates if the upgrade should be skipped
 
 inputs:
-  zarf-yaml:
+  check-flavor-zarf-yaml:
     default: zarf.yaml
     description: Relative path of a zarf.yaml containing flavors to check
 
@@ -40,5 +40,5 @@ runs:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set output
-        echo "upgrade-flavors=$(cat ${{ inputs.zarf-yaml }} | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
+        echo "upgrade-flavors=$(cat ${{ inputs.check-flavor-zarf-yaml }} | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/test-flavor/action.yaml
+++ b/.github/actions/test-flavor/action.yaml
@@ -9,6 +9,11 @@ outputs:
     value: ${{ steps.set-required.outputs.upgrade-flavors }}
     description: Indicates if the upgrade should be skipped
 
+inputs:
+  zarf-yaml:
+    default: zarf.yaml
+    description: Relative path of a zarf.yaml containing flavors to check
+
 runs:
   using: composite
   steps:
@@ -35,5 +40,5 @@ runs:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set output
-        echo "upgrade-flavors=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
+        echo "upgrade-flavors=$(cat ${{ inputs.zarf-yaml }} | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -16,6 +16,8 @@ spec:
       default: ${IRON_BANK_ROBOT_PASSWORD}
     chainguard-identity:
       default: ${CHAINGUARD_IDENTITY}
+    check-flavor-zarf-yaml:
+      default: zarf.yaml
 ---
 test:
   id_tokens:
@@ -38,7 +40,7 @@ test:
         git checkout "$TAG"
 
         # Extract upgrade flavors and set UPGRADE_FLAVORS
-        UPGRADE_FLAVORS=$(cat zarf.yaml | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "")
+        UPGRADE_FLAVORS=$(cat $[[ inputs.check-flavor-zarf-yaml ]] | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo "")
 
         # change back to the commit branch for the rest of the job
         git checkout -


### PR DESCRIPTION
## Description

Allows alternate paths for the check flavor zarf.yaml

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
