### PR TITLE
fix: gitlab publish being broken due to bash weirdness

### DIFF
--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -65,16 +65,20 @@ publish:
           TASK_NAME="publish-release"
         fi
 
-        ARGS="--set FLAVOR=\"$[[ inputs.flavor ]]\" \
-              --set VERSION=\"$(uds-releaser show ${FLAVOR} --version-only)\""
+        ARGS=(
+          --set FLAVOR="$[[ inputs.flavor ]]"
+          --set VERSION="$(uds-releaser show $[[ inputs.flavor ]] --version-only)"
+        )
 
         if [[ -n "$[[ inputs.target-repo ]]" ]]; then
-          ARGS+=" --set TARGET_REPO=\"$[[ inputs.target-repo ]]\""
+          ARGS+=(--set TARGET_REPO="$[[ inputs.target-repo ]]")
         else
-          ARGS+=" --set TEAM=\"$[[ inputs.team ]]\""
+          ARGS+=(--set TEAM="$[[ inputs.team ]]")
         fi
 
-        uds run $TASK_NAME ${ARGS} ${OPTIONS}
+        echo Running $TASK_NAME "${ARGS[@]}" ${OPTIONS}
+
+        uds run $TASK_NAME "${ARGS[@]}" ${OPTIONS}
 
     # Create tag and release
     - |


### PR DESCRIPTION
## Description

When you have escaped double quotes in a bash variable bash does some weird single quote things that the command actually ran looks like this
```
--set 'FLAVOR="upstream"'
```
which breaks our stuff
Fix is to switch to a bash array for keeping track of everything:
```
        ARGS=(
          --set FLAVOR="$[[ inputs.flavor ]]"
          --set VERSION="$(uds-releaser show $[[ inputs.flavor ]] --version-only)"
        )

          ARGS+=(--set TARGET_REPO="$[[ inputs.target-repo ]]")
```

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
