### PR TITLE
feat: allow keycloak_group to be specified as input in create-doug-user task

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -54,7 +54,7 @@ tasks:
     inputs:
       keycloak_group:
         description: Group to add user to
-        default: ""
+        default: "$KEYCLOAK_GROUP"
         required: false
     actions:
       - description: Creating the 'doug' user in the 'uds' realm

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -54,7 +54,7 @@ tasks:
     inputs:
       keycloak_group:
         description: Group to add user to
-        default: "$KEYCLOAK_GROUP"
+        default: $KEYCLOAK_GROUP
         required: false
     actions:
       - description: Creating the 'doug' user in the 'uds' realm

--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -51,9 +51,15 @@ tasks:
 
   - name: create-doug-user
     description: Creates a user named 'doug' in the uds realm of keycloak (using the default admin account)
+    inputs:
+      keycloak_group:
+        description: Group to add user to
+        default: ""
+        required: false
     actions:
       - description: Creating the 'doug' user in the 'uds' realm
         cmd: |
+          KEYCLOAK_GROUP="${{ .inputs.keycloak_group }}"
           KEYCLOAK_ADMIN_PASSWORD=$(./uds zarf tools kubectl get secret -n keycloak keycloak-admin-password -o jsonpath='{.data.password}' | base64 -d)
           KEYCLOAK_ADMIN_TOKEN=$(curl -s --location "https://keycloak.admin.uds.dev/realms/master/protocol/openid-connect/token" \
             --header "Content-Type: application/x-www-form-urlencoded" \


### PR DESCRIPTION
## Description
Allow `keycloak_group` input in `create-doug-user` task to add doug user to specified group, for example:

```yaml
- name: create-admin-doug
  actions:
    - task: setup:create-doug-user
      with:
        keycloak_group: /UDS Core/Admin
```

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
