### PR TITLE
fix: use flavor from inputs instead of $FLAVOR variable

### DIFF
--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -85,7 +85,7 @@ publish:
       if [[ "$DRY_RUN" == "true" ]]; then
         echo "Dry run, skipping release"
       else
-        uds-releaser release gitlab "${FLAVOR}"
+        uds-releaser release gitlab "$[[ inputs.flavor ]]"
       fi
 
   after_script:

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -49,13 +49,13 @@ publish:
 
     # Check if release is necessary for flavor and exit early if not
     - |
-      if ! uds-releaser check "${FLAVOR}"; then
+      if ! uds-releaser check "$[[ inputs.flavor ]]"; then
         echo "No release necessary"
         [[ "$DRY_RUN" != "true" ]] && exit 0
       fi
 
     # Modify zarf package and uds bundle to have the correct version
-    - uds-releaser update-yaml ${FLAVOR}
+    - uds-releaser update-yaml $[[ inputs.flavor ]]
 
     # Publish Package
     - |


### PR DESCRIPTION
## Description

Part of the gitlab publish template was assuming the flavor would be in a variable called FLAVOR instead of using the defined input as the interface into this component.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
