### PR TITLE
fix: add git reset in upgrade-test directory for better local devx

### DIFF
--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -65,6 +65,7 @@ tasks:
           darwin: bash
         dir: upgrade-test
         cmd: |
+          git reset --hard HEAD
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
           TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
           git checkout "$TAG"


### PR DESCRIPTION
## Description

add git reset in upgrade-test directory on test-upgrade task for better local devx

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
