### PR TITLE
chore: fix broken links and change name of package integration guide

### DIFF
--- a/docs/uds-packages/guide.md
+++ b/docs/uds-packages/guide.md
@@ -18,7 +18,7 @@ Integrating a Package fundamentally means:
 
 ### Licensing Considerations
 
-- Defense Unicorns creates Apache 2.0 licensed products exclusively, see the [Open Source Policy](https://github.com/defenseunicorns/uds-common/blob/main/docs/adrs/0002-apache-2.0-for-all-uds-products.md).
+- Defense Unicorns has adopted the Affero General Public License (v3) for all UDS products, with the option for a commercial license for partners who require it. [Open Source Policy](https://github.com/defenseunicorns/uds-common/blob/main/docs/adrs/0004-agpl-v3-for-all-uds-products.md).
 - Vendors in the marketplace will carry forward their license and associated fees.
 - When in doubt, ask in the #product-support channel in Slack. Legal and Business considerations are being evaluated.
 
@@ -30,7 +30,7 @@ Before beginning the integration process, familiarize yourself with the followin
 1. [UDS Capabilities Documentation](https://uds.defenseunicorns.com/overview/uds-structure/#uds-core-capabilities): Provides information about UDS, UDS CLI, UDS Core, and UDS Bundles.
 2. [Zarf Documentation](https://docs.zarf.dev): Zarf is a tool for declarative creation & distribution of software packages.
 3. [UDS Common Repository](https://github.com/defenseunicorns/uds-common): Contains information and best practices for UDS integration.
-4. [UDS Applications Tracker](https://www.notion.so/138e512f24fc805b9d87f952b289cf4f?v=7be5d4ddbcd94d2580b1388fe935c166): Lists many backlogged and completed applications for UDS integration.
+4. **UDS Applications Tracker**: Lists many backlogged and completed applications for UDS integration.
 5. Briefly review [Pepr Documentation](https://docs.pepr.dev/): it may become useful when you begin integrating with UDS Core.
 
 ## Integration Checklist

--- a/docs/uds-packages/guide.md
+++ b/docs/uds-packages/guide.md
@@ -1,4 +1,4 @@
-# UDS Marketplace Package Integration Guide
+# UDS Airgap App Store Package Integration Guide
 
 ## Introduction
 
@@ -30,7 +30,7 @@ Before beginning the integration process, familiarize yourself with the followin
 1. [UDS Capabilities Documentation](https://uds.defenseunicorns.com/overview/uds-structure/#uds-core-capabilities): Provides information about UDS, UDS CLI, UDS Core, and UDS Bundles.
 2. [Zarf Documentation](https://docs.zarf.dev): Zarf is a tool for declarative creation & distribution of software packages.
 3. [UDS Common Repository](https://github.com/defenseunicorns/uds-common): Contains information and best practices for UDS integration.
-4. [UDS Applications Tracker](https://coda.io/d/Product_dGmk3eNjmm8/Applications_suCbOWqL#_lu8fEKSc): Lists many backlogged and completed applications for UDS integration.
+4. [UDS Applications Tracker](https://www.notion.so/138e512f24fc805b9d87f952b289cf4f?v=7be5d4ddbcd94d2580b1388fe935c166): Lists many backlogged and completed applications for UDS integration.
 5. Briefly review [Pepr Documentation](https://docs.pepr.dev/): it may become useful when you begin integrating with UDS Core.
 
 ## Integration Checklist

--- a/docs/uds-packages/requirements/uds-package-requirements.md
+++ b/docs/uds-packages/requirements/uds-package-requirements.md
@@ -38,8 +38,8 @@ _a Silver UDS Package integrates with the main features of the UDS Operator, is 
 Silver packages:
 
 - [ ] **Must** satisfy all the requirements of [Bronze](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/requirements/uds-package-requirements.md#bronze) Packages
-- [ ] **Must** define network policies under the `allow` key as required in the [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/configuration/uds-operator.md)
-- [ ] **Must** (except if the application provides no end user login) use and create a Keycloak client through the `sso` key. [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/configuration/uds-operator.md)
+- [ ] **Must** define network policies under the `allow` key as required in the [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/reference/configuration/uds-operator.md)
+- [ ] **Must** (except if the application provides no end user login) use and create a Keycloak client through the `sso` key. [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/reference/configuration/uds-operator.md)
 - [ ] **Must** (except if the application provides no application metrics) implement monitors for each application metrics endpoint using it's built-in chart monitors, `monitor` key, or manual monitors in the config chart.
 - [ ] **Must** integrate declaratively (i.e. no clickops) with the UDS Operator
 - [ ] **Should** expose all configuration (`uds.dev` CRs, additional `Secrets`/`ConfigMap`s, etc) through a Helm chart (ideally in a `chart` or `charts` directory).
@@ -65,7 +65,7 @@ Bronze packages:
 
 - [ ] **Should** be created from the [UDS Package Template](https://github.com/defenseunicorns/uds-package-template)
 - [ ] **Must** be declaratively bundled in a [Zarf package](https://docs.zarf.dev/ref/create/)
-- [ ] **Must** define any external interfaces under the `expose` key in the [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/configuration/uds-operator.md)
+- [ ] **Must** define any external interfaces under the `expose` key in the [UDS Package Custom Resource](https://github.com/defenseunicorns/uds-core/blob/main/docs/reference/configuration/uds-operator.md)
 - [ ] **Must** deploy and operate successfully with Istio injection enabled in the namespace.
 - [ ] **Must** implement Journey testing, covering the basic user flows and features of the application (see [Testing Guidelines](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/guidelines/testing-guidelines.md))
 - [ ] **Must** implement Upgrade Testing to ensure that the current development package works when deployed over the previously released one. (see [Testing Guidelines](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/guidelines/testing-guidelines.md))


### PR DESCRIPTION
## Description

- fix broken links in `docs/uds-packages/guide.md` and `docs/uds-packages/requirements/uds-package-requirements.md`.
- Change name of `UDS Marketplace Package Integration Guide` to `UDS Airgap App Store Package Integration Guide`

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
