### PR TITLE
chore: add a renovate rule for handling uds versions from upstream ones

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -92,6 +92,22 @@
             ],
             "datasourceTemplate": "npm"
         },
+        // Matches specified datasources where a uds.x package version needs to be updated from an upstream source 
+        {
+            "fileMatch": [".*\\.ya?ml$"],
+            "matchStringsStrategy": "recursive",
+            "matchStrings": [
+                // Test: https://regex101.com/r/a7CxKB/1
+                "# renovate-uds: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*:\\s*['\"]?[v0-9].*?['\"]?(\\s|$)",
+                // Test: https://regex101.com/r/TIh2K7/1
+                ":\\s*['\"]?[v0-9].*?['\"]?(\\s|$)",
+                // Test: https://regex101.com/r/euvVHz/1
+                "(?<currentValue>[v0-9][^\\n\\\"\\s]*)-uds\\.\\d+"
+            ],
+            "autoReplaceStringTemplate": "{{{newValue}}}-uds.0",
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+            "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+        },
         // Matches specified datasources where a colon separates the version on the following line (i.e. https://github.com/defenseunicorns/zarf/blob/7e91d3b9823b52fe6d0f563d692c8af57faa6005/examples/big-bang/zarf.yaml#L5)
         {
             "fileMatch": [".*\\.ya?ml$"],

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -3,11 +3,11 @@
 
 flavors:
   - name: upstream
-    # renovate: datasource=docker depName=nginx versioning=semver-coerced
-    version: 1.27.3
+    # renovate-uds: datasource=docker depName=nginx
+    version: 1.27.3-uds.0
   - name: registry1
-    # renovate: datasource=docker depName=registry1.dso.mil/ironbank/opensource/nginx/nginx versioning=semver-coerced
-    version: 1.27.3
+    # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/nginx/nginx
+    version: 1.27.3-uds.0
   - name: unicorn
-    # renovate: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/nginx versioning=semver-coerced
-    version: 1.27.3
+    # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/nginx
+    version: 1.27.3-uds.0

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -149,5 +149,3 @@ tasks:
 
       - description: Publish the packages
         task: publish:package
-        with:
-          version: ${VERSION}

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -21,7 +21,7 @@ tasks:
         default: .
       version:
         description: The version of the package to publish
-        required: true
+        default: ${VERSION}
       architecture:
         description: The architecture of the package to publish
         default: ${UDS_ARCH}

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -83,7 +83,7 @@ tasks:
             --no-progress \
             -o ${{ .inputs.path }}
 
-          mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
+          mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION%-*}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
 
           # Run any dependency commands (i.e. uds run dependencies:create)
           sh -c "${{ .inputs.dep_commands }}"

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -72,6 +72,7 @@ tasks:
 
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
+          LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
           LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
@@ -81,6 +82,8 @@ tasks:
             "oci://${TARGET_REPO}/${PACKAGE_NAME}:${LATEST_VERSION}" \
             --no-progress \
             -o ${{ .inputs.path }}
+
+          mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
 
           # Run any dependency commands (i.e. uds run dependencies:create)
           sh -c "${{ .inputs.dep_commands }}"


### PR DESCRIPTION
## Description

This adds a renovate rule to handle `-uds.x` versions correctly when mixed with upstream versions.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
