### PR TITLE
fix: flavors containing a dash will fail on the upgrade task

### DIFF
--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -83,7 +83,7 @@ tasks:
             --no-progress \
             -o ${{ .inputs.path }}
 
-          mv -n "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION%-${FLAVOR}}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
+          mv -n "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION%-"${FLAVOR}"}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
 
           # Run any dependency commands (i.e. uds run dependencies:create)
           sh -c "${{ .inputs.dep_commands }}"

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -83,7 +83,7 @@ tasks:
             --no-progress \
             -o ${{ .inputs.path }}
 
-          mv -n "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION%-*}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
+          mv -n "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION%-${FLAVOR}}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
 
           # Run any dependency commands (i.e. uds run dependencies:create)
           sh -c "${{ .inputs.dep_commands }}"


### PR DESCRIPTION
## Description

This fixes an issue where flavors containing a dash break on upgrade.

Fixes: #373 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
