### PR TITLE
chore: add private back to other orgs and restrict teams

### DIFF
--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -32,15 +32,22 @@ tasks:
           fi
           repo="${{ .inputs.base_repo }}"
           # unicorn flavor = private repository
-          if [ "${{ .inputs.flavor }}" = "unicorn" ] && [ "${{ .inputs.base_repo }}" = "ghcr.io/defenseunicorns/packages" ]; then
+          if [ "${{ .inputs.flavor }}" = "unicorn" ]; then
             repo="${repo}/private"
           fi
-          repo="${repo}/${{ .inputs.team }}"
+          # Use substring matching to not apply when in the uds-packages org
+          if [[ "${{ .inputs.base_repo }}" != *"ghcr.io/uds-packages"* ]]; then
+            repo="${repo}/${{ .inputs.team }}"
+          fi
+
           # snapshots = snapshot repository
           if [ "${{ .inputs.snapshot }}" = "true" ]; then
             repo="${repo}/snapshots"
           fi
           echo "${repo}"
         mute: true
+        shell:
+          darwin: bash
+          linux: bash
         setVariables:
           - name: TARGET_REPO

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -36,6 +36,7 @@ tasks:
             repo="${repo}/private"
           fi
           # Use substring matching to not apply when in the uds-packages org
+          # shellcheck disable=SC2193
           if [[ "${{ .inputs.base_repo }}" != *"ghcr.io/uds-packages"* ]]; then
             repo="${repo}/${{ .inputs.team }}"
           fi


### PR DESCRIPTION
# update repo logic to apply private paths more widely and don't apply teams to uds-packages org

## Tests:

Task ran to what would be the publish command

```
uds run publish:package --set ENABLE_UDS_RELEASER="true" --set FLAVOR=upstream --set BASE_REPO=ghcr.io/uds-packages
uds zarf package publish ./zarf-package-nginx-amd64-1.27.3-uds.0.tar.zst oci://ghcr.io/uds-packages

uds run publish:package --set ENABLE_UDS_RELEASER="true" --set FLAVOR=unicorn --set BASE_REPO=ghcr.io/uds-packages
uds zarf package publish ./zarf-package-nginx-amd64-1.27.3-uds.0.tar.zst oci://ghcr.io/uds-packages/private

uds run publish:package --set ENABLE_UDS_RELEASER="true" --set FLAVOR=upstream
uds zarf package publish ./zarf-package-nginx-amd64-1.27.3-uds.0.tar.zst oci://ghcr.io/defenseunicorns/packages/uds

uds run publish:package --set ENABLE_UDS_RELEASER="true" --set FLAVOR=unicorn
uds zarf package publish ./zarf-package-nginx-amd64-1.27.3-uds.0.tar.zst oci://ghcr.io/defenseunicorns/packages/private/uds
```