### PR TITLE
chore: added a way to pass license keys

### DIFF
--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -34,10 +34,6 @@ on:
         type: boolean
         description: "Whether to append LICENSE_KEY to the test command"
         default: false
-    secrets:
-      LICENSE_KEY:
-        required: false
-        description: "License key for packages that require it"        
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -30,6 +30,10 @@ on:
         # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
         default: 0.17.0
         type: string
+      requires_license:
+        type: boolean
+        description: "Whether to append LICENSE_KEY to the test command"
+        default: false        
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -70,7 +74,7 @@ jobs:
         shell: bash
 
       - name: Test
-        run: uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}" --set LICENSE_KEY="${{ secrets.LICENSE_KEY }}"
+        run: uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}"${{ inputs.requires_license == true && ' --set LICENSE_KEY="' + secrets.LICENSE_KEY + '"' || '' }}
         shell: bash
 
       - name: UDS Badge Verification

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -30,10 +30,6 @@ on:
         # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
         default: 0.17.0
         type: string
-      requires_license:
-        type: boolean
-        description: "Whether to append LICENSE_KEY to the test command"
-        default: false
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -74,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Test
-        run: uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}"
+        run: uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}" --set LICENSE_KEY="${{ secrets.LICENSE_KEY }}"
         shell: bash
 
       - name: UDS Badge Verification

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -30,6 +30,14 @@ on:
         # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
         default: 0.17.0
         type: string
+      requires_license:
+        type: boolean
+        description: "Whether to append LICENSE_KEY to the test command"
+        default: false
+    secrets:
+      LICENSE_KEY:
+        required: false
+        description: "License key for packages that require it"        
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:


### PR DESCRIPTION
## Description

added `requires_license` and a way to potentially get LICENSE_KEY inherited to child job in packages like `uds-package-jira` (and other more license restrictive products) 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
