### PR TITLE
feat: do not run commitlint on draft MRs

### DIFF
--- a/templates/commitlint.yml
+++ b/templates/commitlint.yml
@@ -8,7 +8,7 @@ spec:
 ---
 commitlint:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TITLE !~ /^Draft/
   script:
     - npm install --save-dev @commitlint/config-conventional@19.7.1
     - npm install --save-dev @commitlint/cli@19.7.1


### PR DESCRIPTION
## Description

commitlint shouldn't run on draft MRs in GitLab

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
