### PR TITLE
feat: expose UDS CLI flag options for GitLab test template

### DIFF
--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -212,14 +212,14 @@ tasks:
         if: ${{ eq .variables.TYPE "install" }}
         cmd: |
           if uds run --list | grep -q 'test-package'; then
-            ./uds run test-package --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
+            ./uds ${{ .variables.OPTIONS }} run test-package --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
           else
-            ./uds run test-install --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
+            ./uds ${{ .variables.OPTIONS }} run test-install --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
           fi
 
       - description: Test upgrading the package/bundle
         if: ${{ eq .variables.TYPE "upgrade" }}
-        cmd: ./uds run test-upgrade --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
+        cmd: ./uds ${{ .variables.OPTIONS }} run test-upgrade --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
 
   - name: verify-badge
     description: Perform verification to assist with UDS badge certification

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -212,14 +212,14 @@ tasks:
         if: ${{ eq .variables.TYPE "install" }}
         cmd: |
           if uds run --list | grep -q 'test-package'; then
-            ./uds ${{ .variables.OPTIONS }} run test-package --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
+            ./uds run test-package --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
           else
-            ./uds ${{ .variables.OPTIONS }} run test-install --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
+            ./uds run test-install --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
           fi
 
       - description: Test upgrading the package/bundle
         if: ${{ eq .variables.TYPE "upgrade" }}
-        cmd: ./uds ${{ .variables.OPTIONS }} run test-upgrade --set FLAVOR=${{ .variables.FLAVOR }} --no-progress
+        cmd: ./uds run test-upgrade --set FLAVOR=${{ .variables.FLAVOR }} ${{ .variables.OPTIONS }} --no-progress
 
   - name: verify-badge
     description: Perform verification to assist with UDS badge certification

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -18,6 +18,8 @@ spec:
       default: ${CHAINGUARD_IDENTITY}
     check-flavor-zarf-yaml:
       default: zarf.yaml
+    options:
+      default: ""
 ---
 test:
   id_tokens:
@@ -66,7 +68,7 @@ test:
                                               --set GITLAB_REGISTRY_TOKEN="$CI_REGISTRY_PASSWORD" \
                                               --set GHCR_REGISTRY_USER="$GH_USER_READ_ONLY" \
                                               --set GHCR_REGISTRY_TOKEN="$GH_PAT_READ_ONLY"
-    - uds run actions:test-deploy --set FLAVOR="$[[ inputs.flavor ]]" --set TYPE="$[[ inputs.type ]]"
+    - uds run actions:test-deploy --set FLAVOR="$[[ inputs.flavor ]]" --set TYPE="$[[ inputs.type ]]" --set OPTIONS="$[[ inputs.options ]]"
     - uds run actions:verify-badge
 
   after_script:


### PR DESCRIPTION
## Description

Allows for setting useful flags like `--insecure` or `--uds-cache` as inputs in the include section of GitLab CI/CD. 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
