### PR TITLE
fix: check addlicense binary in PATH in addition to $HOME/go/bin

### DIFF
--- a/.license_config.yaml
+++ b/.license_config.yaml
@@ -1,0 +1,3 @@
+license: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+copyright: Defense Unicorns
+ignore: []

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -159,56 +159,78 @@ tasks:
   - name: license
     description: Lint for the SPDX license identifier being in source files
     actions:
-      - description: Checking for SPDX headers
+      - description: Checking for SPDX headers using YAML config
         shell:
           darwin: bash
           linux: bash
         cmd: |
-          # check for addlicense bin
-          if [ -x "$HOME/go/bin/addlicense" ]; then
-              echo "addlicense installed in $HOME/go/bin"
-          else
-              echo "Error: addlicense is not installed in $HOME/go/bin" >&2
-              exit 1
+          CONFIG_FILE=".license_config.yaml"
+
+          # Parse configuration from YAML (only license, copyright, and ignore)
+          LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
+          COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+
+          # Exit if license or copyright are not provided
+          if [ -z "$LICENSE" ] || [ "$LICENSE" = "null" ] || [ -z "$COPYRIGHT" ] || [ "$COPYRIGHT" = "null" ]; then
+            echo "License or copyright configuration not provided; exiting."
+            exit 0
           fi
 
-          ignore_flags=()
-          while IFS= read -r line; do
-            # Skip comments and empty lines
-            [ -z "$line" ] || [[ "$line" =~ ^# ]] && continue
-            # Add the line to ignore_flags array with quotes around it
-            ignore_flags+=("-ignore" "\"$line\"")
-          done < .gitignore
+          # Check for addlicense binary
+          if [ ! -x "$HOME/go/bin/addlicense" ]; then
+            echo "Error: addlicense is not installed in $HOME/go/bin" >&2
+            exit 1
+          fi
 
-          # Construct the command as a string
-          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -check -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"
+          # Build ignore flags from config file
+          ignore_flags=()
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            ignore_flags+=("-ignore" "\"$pattern\"")
+          done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+
+          # Construct the addlicense command with hard-coded flags for checking
+          cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -check -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
+          echo "Running: $cmd"
+          eval "$cmd"
 
   - name: fix-license
     description: Add the SPDX license identifier to source files
     actions:
-      - description: Adding SPDX headers
+      - description: Adding SPDX headers using YAML config
         shell:
           darwin: bash
           linux: bash
         cmd: |
-          # check for addlicense bin
-          if [ -x "$HOME/go/bin/addlicense" ]; then
-              echo "addlicense installed in $HOME/go/bin"
-          else
-              echo "Error: addlicense is not installed in $HOME/go/bin" >&2
-              exit 1
+          CONFIG_FILE=".license_config.yaml"
+
+          # Parse configuration from YAML (only license, copyright, and ignore)
+          LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
+          COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+
+          # Exit if license or copyright are not provided
+          if [ -z "$LICENSE" ] || [ "$LICENSE" = "null" ] || [ -z "$COPYRIGHT" ] || [ "$COPYRIGHT" = "null" ]; then
+            echo "License or copyright configuration not provided; exiting."
+            exit 0
           fi
 
-          ignore_flags=()
-          while IFS= read -r line; do
-            # Skip comments and empty lines
-            [ -z "$line" ] || [[ "$line" =~ ^# ]] && continue
-            # Add the line to ignore_flags array with quotes around it
-            ignore_flags+=("-ignore" "\"$line\"")
-          done < .gitignore
+          # Check for addlicense binary
+          if [ ! -x "$HOME/go/bin/addlicense" ]; then
+            echo "Error: addlicense is not installed in $HOME/go/bin" >&2
+            exit 1
+          fi
 
-          # Construct the command as a string
-          eval "$HOME/go/bin/addlicense -l \"AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial\" -s=only -v -c \"Defense Unicorns\" ${ignore_flags[*]} . 2>/dev/null"
+          # Build ignore flags from config file
+          ignore_flags=()
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            ignore_flags+=("-ignore" "\"$pattern\"")
+          done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+
+          # Construct the addlicense command with hard-coded flags for fixing (omitting -check)
+          cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
+          echo "Running: $cmd"
+          eval "$cmd"
 
   - name: tasks
     description: Dry run all tasks in the base tasks file

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -181,9 +181,9 @@ tasks:
             exit 0
           fi
 
-          # Check for addlicense binary
-          if [ ! -x "$HOME/go/bin/addlicense" ]; then
-            echo "Error: addlicense is not installed in $HOME/go/bin" >&2
+          # Check for addlicense binary in $PATH
+          if ! command -v addlicense >/dev/null 2>&1; then
+            echo "Error: addlicense is not found in PATH" >&2
             exit 1
           fi
 
@@ -226,9 +226,9 @@ tasks:
             exit 0
           fi
 
-          # Check for addlicense binary
-          if [ ! -x "$HOME/go/bin/addlicense" ]; then
-            echo "Error: addlicense is not installed in $HOME/go/bin" >&2
+          # Check for addlicense binary in $PATH
+          if ! command -v addlicense >/dev/null 2>&1; then
+            echo "Error: addlicense is not found in PATH" >&2
             exit 1
           fi
 

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -164,7 +164,7 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
-          CONFIG_FILE="license_config.yaml"
+          CONFIG_FILE=".license_config.yaml"
 
           # If the config file exists, parse its values; otherwise, use default values.
           if [ -f "$CONFIG_FILE" ]; then

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -182,11 +182,13 @@ tasks:
           fi
 
           # Check for addlicense binary. Look in $PATH first with fallback to $HOME/go/bin
-          if ! command -v addlicense >/dev/null 2>&1; then
-            if [ ! -x "$HOME/go/bin/addlicense" ]; then
-              echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
-              exit 1
-            fi
+          if command -v addlicense >/dev/null 2>&1; then
+            ADDLICENSE_CMD="addlicense"
+          elif [ -x "$HOME/go/bin/addlicense" ]; then
+            ADDLICENSE_CMD="$HOME/go/bin/addlicense"
+          else
+            echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
+            exit 1
           fi
 
           # Build ignore flags if the config file exists
@@ -199,7 +201,7 @@ tasks:
           fi
 
           # Construct the addlicense command for linting (includes -check)
-          cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -check -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
+          cmd="$ADDLICENSE_CMD -l \"$LICENSE\" -check -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
           echo "Running: $cmd"
           eval "$cmd"
 
@@ -229,11 +231,13 @@ tasks:
           fi
 
           # Check for addlicense binary. Look in $PATH first with fallback to $HOME/go/bin
-          if ! command -v addlicense >/dev/null 2>&1; then
-            if [ ! -x "$HOME/go/bin/addlicense" ]; then
-              echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
-              exit 1
-            fi
+          if command -v addlicense >/dev/null 2>&1; then
+            ADDLICENSE_CMD="addlicense"
+          elif [ -x "$HOME/go/bin/addlicense" ]; then
+            ADDLICENSE_CMD="$HOME/go/bin/addlicense"
+          else
+            echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
+            exit 1
           fi
 
           # Build ignore flags if the config file exists
@@ -246,7 +250,7 @@ tasks:
           fi
 
           # Construct the addlicense command for fixing (omitting -check)
-          cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
+          cmd="$ADDLICENSE_CMD -l \"$LICENSE\" -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
           echo "Running: $cmd"
           eval "$cmd"
 

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -181,13 +181,16 @@ tasks:
             exit 0
           fi
 
-          # Check for addlicense binary in $PATH
+          # Check for addlicense binary. Look in $PATH first with fallback to $HOME/go/bin
           if ! command -v addlicense >/dev/null 2>&1; then
-            echo "Error: addlicense is not found in PATH" >&2
-            exit 1
+            if [ ! -x "$HOME/go/bin/addlicense" ]; then
+              echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
+              exit 1
+            fi
           fi
+  
 
-          # Build ignore flags if the config file exists
+  # Build ignore flags if the config file exists
           ignore_flags=()
           if [ -f "$CONFIG_FILE" ]; then
             while IFS= read -r pattern; do
@@ -226,10 +229,12 @@ tasks:
             exit 0
           fi
 
-          # Check for addlicense binary in $PATH
+          # Check for addlicense binary. Look in $PATH first with fallback to $HOME/go/bin
           if ! command -v addlicense >/dev/null 2>&1; then
-            echo "Error: addlicense is not found in PATH" >&2
-            exit 1
+            if [ ! -x "$HOME/go/bin/addlicense" ]; then
+              echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
+              exit 1
+            fi
           fi
 
           # Build ignore flags if the config file exists

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -159,18 +159,23 @@ tasks:
   - name: license
     description: Lint for the SPDX license identifier being in source files
     actions:
-      - description: Checking for SPDX headers using YAML config
+      - description: Checking for SPDX headers using YAML config with defaults
         shell:
           darwin: bash
           linux: bash
         cmd: |
-          CONFIG_FILE=".license_config.yaml"
+          CONFIG_FILE="license_config.yaml"
 
-          # Parse configuration from YAML (only license, copyright, and ignore)
-          LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
-          COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+          # If the config file exists, parse its values; otherwise, use default values.
+          if [ -f "$CONFIG_FILE" ]; then
+            LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
+            COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+          else
+            LICENSE="AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial"
+            COPYRIGHT="Defense Unicorns"
+          fi
 
-          # Exit if license or copyright are not provided
+          # Exit if license or copyright are not provided.
           if [ -z "$LICENSE" ] || [ "$LICENSE" = "null" ] || [ -z "$COPYRIGHT" ] || [ "$COPYRIGHT" = "null" ]; then
             echo "License or copyright configuration not provided; exiting."
             exit 0
@@ -182,14 +187,16 @@ tasks:
             exit 1
           fi
 
-          # Build ignore flags from config file
+          # Build ignore flags if the config file exists
           ignore_flags=()
-          while IFS= read -r pattern; do
-            [ -z "$pattern" ] && continue
-            ignore_flags+=("-ignore" "\"$pattern\"")
-          done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+          if [ -f "$CONFIG_FILE" ]; then
+            while IFS= read -r pattern; do
+              [ -z "$pattern" ] && continue
+              ignore_flags+=("-ignore" "\"$pattern\"")
+            done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+          fi
 
-          # Construct the addlicense command with hard-coded flags for checking
+          # Construct the addlicense command for linting (includes -check)
           cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -check -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
           echo "Running: $cmd"
           eval "$cmd"
@@ -197,18 +204,23 @@ tasks:
   - name: fix-license
     description: Add the SPDX license identifier to source files
     actions:
-      - description: Adding SPDX headers using YAML config
+      - description: Adding SPDX headers using YAML config with defaults
         shell:
           darwin: bash
           linux: bash
         cmd: |
-          CONFIG_FILE=".license_config.yaml"
+          CONFIG_FILE="license_config.yaml"
 
-          # Parse configuration from YAML (only license, copyright, and ignore)
-          LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
-          COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+          # If the config file exists, parse its values; otherwise, use default values.
+          if [ -f "$CONFIG_FILE" ]; then
+            LICENSE=$(uds zarf tools yq e '.license' "$CONFIG_FILE")
+            COPYRIGHT=$(uds zarf tools yq e '.copyright' "$CONFIG_FILE")
+          else
+            LICENSE="AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial"
+            COPYRIGHT="Defense Unicorns"
+          fi
 
-          # Exit if license or copyright are not provided
+          # Exit if license or copyright are not provided.
           if [ -z "$LICENSE" ] || [ "$LICENSE" = "null" ] || [ -z "$COPYRIGHT" ] || [ "$COPYRIGHT" = "null" ]; then
             echo "License or copyright configuration not provided; exiting."
             exit 0
@@ -220,14 +232,16 @@ tasks:
             exit 1
           fi
 
-          # Build ignore flags from config file
+          # Build ignore flags if the config file exists
           ignore_flags=()
-          while IFS= read -r pattern; do
-            [ -z "$pattern" ] && continue
-            ignore_flags+=("-ignore" "\"$pattern\"")
-          done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+          if [ -f "$CONFIG_FILE" ]; then
+            while IFS= read -r pattern; do
+              [ -z "$pattern" ] && continue
+              ignore_flags+=("-ignore" "\"$pattern\"")
+            done < <(uds zarf tools yq e '.ignore[]' "$CONFIG_FILE")
+          fi
 
-          # Construct the addlicense command with hard-coded flags for fixing (omitting -check)
+          # Construct the addlicense command for fixing (omitting -check)
           cmd="$HOME/go/bin/addlicense -l \"$LICENSE\" -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
           echo "Running: $cmd"
           eval "$cmd"

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -213,7 +213,7 @@ tasks:
           darwin: bash
           linux: bash
         cmd: |
-          CONFIG_FILE="license_config.yaml"
+          CONFIG_FILE=".license_config.yaml"
 
           # If the config file exists, parse its values; otherwise, use default values.
           if [ -f "$CONFIG_FILE" ]; then

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -188,9 +188,8 @@ tasks:
               exit 1
             fi
           fi
-  
 
-  # Build ignore flags if the config file exists
+          # Build ignore flags if the config file exists
           ignore_flags=()
           if [ -f "$CONFIG_FILE" ]; then
             while IFS= read -r pattern; do


### PR DESCRIPTION
## Description
Updated the validation logic to check for the addlicense binary in the system PATH in addition to a hardcoded $HOME/go/bin directory. This ensures better compatibility across environments.

This should be merged AFTER #409 since this branch was created from that branch's HEAD.

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
