### PR TITLE
fix: add ignored_version input for upgrades

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -79,7 +79,7 @@ tasks:
           # -e SC2001 Ignore sed replace suggestions (${text//search/replacement} syntax doesn't support regex so this suggestion often won't work)
           # -e SC2002 Ignore rejection of `cat |` (redirection syntax is not always familiar to developers and while cat _could_ not exist that is extremely unlikely)
           # -e SC2181 Ignore rejection of $? ($? can be confusing in some circumstances but also more readable in others with more complex commands)
-          export SHELLCHECK_OPTS="-x -e SC2016 -e SC2050 -e SC2001 -e SC2002 -e SC2181"
+          export SHELLCHECK_OPTS="-x -e SC2016 -e SC2050 -e SC2001 -e SC2002 -e SC2181 -e SC2157"
 
           # Function to lint scripts inside `---` delimited files
           lint_scripts() {

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -79,7 +79,7 @@ tasks:
           # -e SC2001 Ignore sed replace suggestions (${text//search/replacement} syntax doesn't support regex so this suggestion often won't work)
           # -e SC2002 Ignore rejection of `cat |` (redirection syntax is not always familiar to developers and while cat _could_ not exist that is extremely unlikely)
           # -e SC2181 Ignore rejection of $? ($? can be confusing in some circumstances but also more readable in others with more complex commands)
-          export SHELLCHECK_OPTS="-x -e SC2016 -e SC2050 -e SC2001 -e SC2002 -e SC2181 -e SC2157"
+          export SHELLCHECK_OPTS="-x -e SC2016 -e SC2050 -e SC2001 -e SC2002 -e SC2181"
 
           # Function to lint scripts inside `---` delimited files
           lint_scripts() {

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,7 +75,11 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+          if [ -z "${{ .inputs.ignored_versions }}" ]; then
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          else
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+          fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -76,7 +76,11 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          LATEST_VERSION="1.0.0"
+          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          else
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+          fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,7 +75,8 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          if [ -z "${{ .inputs.ignored_versions }}" ]; then
+          # shellcheck disable=SC2157
+          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -67,6 +67,7 @@ tasks:
           darwin: bash
         dir: upgrade-test
         cmd: |
+          set -x
           git reset --hard HEAD
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
           TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -67,7 +67,6 @@ tasks:
           darwin: bash
         dir: upgrade-test
         cmd: |
-          set -x
           git reset --hard HEAD
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
           TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -76,6 +76,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
+          # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -67,6 +67,7 @@ tasks:
           darwin: bash
         dir: upgrade-test
         cmd: |
+          set -x
           git reset --hard HEAD
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
           TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
@@ -75,10 +76,10 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          if [[ "${{ .inputs.ignored_versions }}" != "" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
-          else
+          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          else
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,7 +75,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
+          if [[ "${{ .inputs.ignored_versions }}" != "" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -76,11 +76,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
-          else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
-          fi
+          LATEST_VERSION="1.0.0"
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,11 +75,10 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          IGNORED_VERSIONS=${{ index .inputs "ignored_versions" }}
-          if [[ -z "${IGNORED_VERSIONS}" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          if [[ "${{ .inputs.ignored_versions }}" != "" ]]; then
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
           else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${IGNORED_VERSIONS}" | grep "${FLAVOR}" | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -76,12 +76,13 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
+          # Ignore shellcheck because of Maru variable usage
           # shellcheck disable=SC2157
-          # if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
-          #   LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
-          # else
-          #   LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
-          # fi
+          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          else
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+          fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,7 +75,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          IGNORED_VERSIONS=${{ .inputs.ignored_versions }}
+          IGNORED_VERSIONS="${{ .inputs.ignored_versions }}"
           if [[ -z "${IGNORED_VERSIONS}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -37,6 +37,10 @@ tasks:
         description: Additional commands to run inside the old repo to setup dependencies
         default: ""
 
+      ignored_versions:
+        description: Regex for versions to ignore (used by filter logic), useful when version scheme has changed and automatic sorting is not pulling the latest version
+        default: ""
+
     actions:
       - task: utils:determine-repo
         with:
@@ -71,7 +75,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -77,11 +77,11 @@ tasks:
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
           # shellcheck disable=SC2157
-          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
-          else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
-          fi
+          # if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
+          #   LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
+          # else
+          #   LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+          # fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
 

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,7 +75,7 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          IGNORED_VERSIONS="${{ .inputs.ignored_versions }}"
+          IGNORED_VERSIONS=${{ index .inputs "ignored_versions" }}
           if [[ -z "${IGNORED_VERSIONS}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -67,7 +67,6 @@ tasks:
           darwin: bash
         dir: upgrade-test
         cmd: |
-          set -x
           git reset --hard HEAD
           BUNDLE_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
           TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
@@ -76,8 +75,6 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          # Ignore shellcheck because of Maru variable usage
-          # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -75,10 +75,11 @@ tasks:
           # VARIABLES
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
-          if [[ "${{ .inputs.ignored_versions }}" != "" ]]; then
+          IGNORED_VERSIONS=${{ .inputs.ignored_versions }}
+          if [[ -z "${IGNORED_VERSIONS}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${IGNORED_VERSIONS}" | grep "${FLAVOR}" | sort -V | tail -1)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -79,7 +79,7 @@ tasks:
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${FLAVOR}" | sort -V | tail -1)
           else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${FLAVOR}" | sort -V | tail -1)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)


### PR DESCRIPTION
## Description

Certain packages (jenkins in particular) have changed versioning schemas, causing a default sort to pull the wrong version in CI. This adds a lightweight grep to ignore certain versions.

Validated on https://github.com/defenseunicorns/uds-package-jenkins/pull/146/commits/92c821d15df36a56f37ebcbdfd153b1289cb8d47

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
