### PR TITLE
fix: update renovate config to support raw github references with/without 'refs/tags/' in the url

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -67,8 +67,8 @@
                 ".*(\\.ya?ml|\\.json)$"
             ],
             "matchStrings": [
-                // Test: https://regex101.com/r/r1nWoZ/1
-                "https:\\/\\/raw\\.githubusercontent\\.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(?<currentValue>[^\\/]+)"
+                // Test: https://regex101.com/r/az0LMu/2
+                "https:\\/\\/raw\\.githubusercontent\\.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(refs\\/tags\\/)?(?<currentValue>[^\\/]+)",
             ],
             "versioningTemplate": "semver-coerced",
             "datasourceTemplate": "github-tags"


### PR DESCRIPTION
## Description

...

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
