### PR TITLE
chore: switch all references from uds-releaser to uds-pk and use non deprecated cli commands

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -28,7 +28,12 @@ on:
         default: 40
       uds-pk:
         type: boolean
+        default: true
+        description: "Whether to use the uds-pk for publishing"
+      uds-releaser:
+        type: boolean
         default: false
+        description: "DEPRECATED: Whether to use the UDS Releaser for publishing"
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -65,8 +70,21 @@ jobs:
             --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
+      - name: Parse inputs
+        id: parse-inputs
+        run: |
+          if [ "${{ inputs.uds-releaser }}" = "true" ]; then
+            echo "::warning title=Deprecated-Input::The `uds-releaser` input is deprecated, please use `uds-pk` instead"
+            echo "uds-pk=true" >> "$GITHUB_OUTPUT"
+          else if [ "${{ inputs.uds-pk }}" = "false" ]; then
+            echo "uds-pk=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "uds-pk=true" >> "$GITHUB_OUTPUT"
+          fi
+
+
       - name: Publish Packages/Bundles - release-please
-        if: ${{ inputs.uds-pk == false }}
+        if: ${{ steps.parse-inputs.uds-pk == false }}
         run: |
           if uds run --list | grep -q 'publish-package'; then
             uds run publish-package --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
@@ -75,7 +93,7 @@ jobs:
           fi
 
       - name: Publish Packages/Bundles - uds-pk
-        if: ${{ inputs.uds-pk == true }}
+        if: ${{ steps.parse-inputs.uds-pk == true }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -26,7 +26,7 @@ on:
       timeout:
         type: number
         default: 40
-      uds-releaser:
+      uds-pk:
         type: boolean
         default: false
 
@@ -66,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Publish Packages/Bundles - release-please
-        if: ${{ inputs.uds-releaser == false }}
+        if: ${{ inputs.uds-pk == false }}
         run: |
           if uds run --list | grep -q 'publish-package'; then
             uds run publish-package --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
@@ -74,13 +74,13 @@ jobs:
             uds run publish-release --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
           fi
 
-      - name: Publish Packages/Bundles - uds-releaser
-        if: ${{ inputs.uds-releaser == true }}
+      - name: Publish Packages/Bundles - uds-pk
+        if: ${{ inputs.uds-pk == true }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if uds-releaser check "${{ inputs.flavor }}"; then
-            uds-releaser update-yaml ${{ inputs.flavor }}
+          if uds-pk release check "${{ inputs.flavor }}"; then
+            uds-pk release update-yaml ${{ inputs.flavor }}
             if uds run --list | grep -q 'publish-package'; then
               uds run publish-package \
                 --set USE_CHECKPOINT=false \

--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -103,13 +103,13 @@ jobs:
               uds run publish-package \
                 --set USE_CHECKPOINT=false \
                 --set FLAVOR=${{ inputs.flavor }} \
-                --set ENABLE_UDS_RELEASER=true \
+                --set ENABLE_UDS_PK=true \
                 --no-progress ${{ inputs.options }}
             else
               uds run publish-release \
                 --set USE_CHECKPOINT=false \
                 --set FLAVOR=${{ inputs.flavor }} \
-                --set ENABLE_UDS_RELEASER=true \
+                --set ENABLE_UDS_PK=true \
                 --no-progress ${{ inputs.options }}
             fi
           fi

--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -29,7 +29,7 @@ on:
       uds-pk:
         type: boolean
         default: true
-        description: "Whether to use the uds-pk for publishing"
+        description: Whether to use the uds-pk for publishing
       uds-releaser:
         type: boolean
         default: false
@@ -74,9 +74,9 @@ jobs:
         id: parse-inputs
         run: |
           if [ "${{ inputs.uds-releaser }}" = "true" ]; then
-            echo "::warning title=Deprecated-Input::The `uds-releaser` input is deprecated, please use `uds-pk` instead"
+            echo "::warning title=Deprecated-Input::The uds-releaser input is deprecated, please use uds-pk instead"
             echo "uds-pk=true" >> "$GITHUB_OUTPUT"
-          else if [ "${{ inputs.uds-pk }}" = "false" ]; then
+          elif [ "${{ inputs.uds-pk }}" = "false" ]; then
             echo "uds-pk=false" >> "$GITHUB_OUTPUT"
           else
             echo "uds-pk=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -273,7 +273,7 @@ jobs:
 
                 if [[ "$imageName" == "$sbomName" ]]; then
                 # Allow different images is necessary because of implied urls with docker hub images (i.e. docker.io/library isn't always present)
-                COMMENT_MARKDOWN+=$(uds-releaser compare-scans "sbom-scan-results/$sbomScan" "image-scan-results/$imageScan" --allow-different-images)
+                COMMENT_MARKDOWN+=$(uds-pk compare-scans "sbom-scan-results/$sbomScan" "image-scan-results/$imageScan" --allow-different-images)
                 COMMENT_MARKDOWN+=$'\n'
               fi
             done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,5 @@ jobs:
     with:
       flavor: ${{ matrix.flavor }}
       runsOn: ${{ matrix.architecture == 'arm64' && 'uds-swf-ubuntu-arm64-4-core' || 'ubuntu-latest' }}
-      uds-releaser: true
+      uds-pk: true
     secrets: inherit # Inherits all secrets from the parent workflow.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -60,7 +60,7 @@ There are multiple task files available in this repository with different object
 |------|-------------|
 | **package** | Publish the UDS package for the supplied architecture |
 | **release-please-publish** | Publish the UDS package using release-please based workflows |
-| **uds-releaser-publish** | Publish the UDS package using uds-releaser based workflows |
+| **uds-pk-publish** | Publish the UDS package using uds-pk based workflows |
 | **test-bundle** | Publish the test bundle for the supplied architecture |
 
 ### [pull.yaml](./tasks/remove.yaml)

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -129,14 +129,14 @@ tasks:
           "https://github.com/defenseunicorns/lula/releases/download/${LULA_VERSION}/lula_${LULA_VERSION}_$(uname -s)_${{ .variables.ARCH }}" \
           && chmod +x /usr/local/bin/lula
 
-      - description: Install uds-releaser
+      - description: Install uds-pk
         env:
-          # renovate: datasource=github-tags depName=defenseunicorns/uds-releaser versioning=semver-coerced
-          - UDS_RELEASER_VERSION=v0.0.8
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-pk versioning=semver-coerced
+          - UDS_PK_VERSION=v0.0.8
         cmd: |
-          curl -o /usr/local/bin/uds-releaser -L \
-          "https://github.com/defenseunicorns/uds-pk/releases/download/${UDS_RELEASER_VERSION}/uds-pk_${UDS_RELEASER_VERSION}_$(uname -s)_${{ .variables.ARCH }}" \
-          && chmod +x /usr/local/bin/uds-releaser
+          curl -o /usr/local/bin/uds-pk -L \
+          "https://github.com/defenseunicorns/uds-pk/releases/download/${UDS_PK_VERSION}/uds-pk_${UDS_PK_VERSION}_$(uname -s)_${{ .variables.ARCH }}" \
+          && chmod +x /usr/local/bin/uds-pk
 
   - name: authenticate-registries
     description: Log in to the registries for testing and publishing UDS Packages

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -42,7 +42,7 @@ tasks:
           team: ${{ .inputs.team }}
           name: ${{ .inputs.name }}
       - if: ${{ eq .variables.ENABLE_UDS_RELEASER "true" }}
-        task: uds-releaser-publish
+        task: uds-pk-publish
         with:
           path: ${{ .inputs.path }}
           architecture: ${{ .inputs.architecture }}
@@ -81,8 +81,8 @@ tasks:
           ./uds zarf package publish "${{ .inputs.path }}/zarf-package-${{ .inputs.name }}-${{ .inputs.architecture }}-${{ .inputs.version }}.tar.zst" "oci://${TARGET_REPO}"
 
 
-  - name: uds-releaser-publish
-    description: Publish the UDS package using uds-releaser based workflows
+  - name: uds-pk-publish
+    description: Publish the UDS package using uds-pk based workflows
     inputs:
       path:
         description: Path to the zarf package being published
@@ -105,14 +105,14 @@ tasks:
         cmd: cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name
         setVariables:
           - name: PACKAGE_NAME
-      - description: publish using uds-releaser
+      - description: publish using uds-pk
         cmd: |
-          ./uds zarf package publish "${{ .inputs.path }}/zarf-package-${{ .inputs.name }}-${{ .inputs.architecture }}-$(uds-releaser release show ${{ .variables.FLAVOR }} --version-only).tar.zst" "oci://${TARGET_REPO}"
+          ./uds zarf package publish "${{ .inputs.path }}/zarf-package-${{ .inputs.name }}-${{ .inputs.architecture }}-$(uds-pk release show ${{ .variables.FLAVOR }} --version-only).tar.zst" "oci://${TARGET_REPO}"
 
           if [ -n "${GITLAB_CI}" ]; then
-            uds-releaser release gitlab "${{ .variables.FLAVOR }}"
+            uds-pk release gitlab "${{ .variables.FLAVOR }}"
           elif [ -n "${GITHUB_ACTION}" ]; then
-            uds-releaser release github "${{ .variables.FLAVOR }}"
+            uds-pk release github "${{ .variables.FLAVOR }}"
           else
             echo "Unsupported platform"
             exit 11

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -9,7 +9,7 @@ variables:
     default: upstream
   - name: TEAM
     default: uds
-  - name: ENABLE_UDS_RELEASER
+  - name: ENABLE_UDS_PK
     default: "false"
   - name: BASE_REPO
 
@@ -33,7 +33,7 @@ tasks:
         description: The name of the package to publish
         default: ${PACKAGE_NAME}
     actions:
-      - if: ${{ eq .variables.ENABLE_UDS_RELEASER "false" }}
+      - if: ${{ eq .variables.ENABLE_UDS_PK "false" }}
         task: release-please-publish
         with:
           path: ${{ .inputs.path }}
@@ -41,7 +41,7 @@ tasks:
           architecture: ${{ .inputs.architecture }}
           team: ${{ .inputs.team }}
           name: ${{ .inputs.name }}
-      - if: ${{ eq .variables.ENABLE_UDS_RELEASER "true" }}
+      - if: ${{ eq .variables.ENABLE_UDS_PK "true" }}
         task: uds-pk-publish
         with:
           path: ${{ .inputs.path }}

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -75,7 +75,7 @@ publish:
 
         ARGS=(
           --set FLAVOR="$[[ inputs.flavor ]]"
-          --set ENABLE_UDS_RELEASER=true
+          --set ENABLE_UDS_PK=true
         )
 
         if [[ -n "$[[ inputs.base-repo ]]" ]]; then

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -57,13 +57,13 @@ publish:
 
     # Check if release is necessary for flavor and exit early if not
     - |
-      if ! uds-releaser check "$[[ inputs.flavor ]]"; then
+      if ! uds-pk check "$[[ inputs.flavor ]]"; then
         echo "No release necessary"
         [[ "$DRY_RUN" != "true" ]] && exit 0
       fi
 
     # Modify zarf package and uds bundle to have the correct version
-    - uds-releaser update-yaml $[[ inputs.flavor ]]
+    - uds-pk update-yaml $[[ inputs.flavor ]]
 
     # Publish Package
     - |
@@ -94,7 +94,7 @@ publish:
     # Mirror package to github
     - |
         if [[ "$[[ inputs.mirror ]]" == "true" ]]; then
-          export PKG_VERSION="$(uds-releaser release show $[[ inputs.flavor ]] --version-only)"
+          export PKG_VERSION="$(uds-pk release show $[[ inputs.flavor ]] --version-only)"
           export PKG_NAME="$(yq '.metadata.name' zarf.yaml)"
           curl -sS --request POST \
             --form "token=${CI_JOB_TOKEN}" \


### PR DESCRIPTION
## Description

switch all references from uds-releaser to uds-pk and use non deprecated cli commands

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
