### PR TITLE
feat: add workflow linting via step security api

### DIFF
--- a/.github/workflows/callable-lint.yaml
+++ b/.github/workflows/callable-lint.yaml
@@ -46,3 +46,4 @@ jobs:
       - name: Lint the repository
         run: |
           uds run lint:all --no-progress
+          uds run lint:workflows --no-progress

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -102,9 +102,9 @@ ignore: [] # an array of paths to ignore
 | **oscal** | Run linting checks on OSCAL |
 | **shell** | Run shellcheck on all Maru tasks, GitHub workflows, and local shell scripts |
 | **license** | Lint for the SPDX license identifier being in source files |
-| **workflows** | Lint for github workflows having their actions being pinned to a specific sha |
+| **workflows** | Lint GitHub workflows |
+| **fix-workflows** | Fix unpinned actions in GitHub workflows |
 | **fix-license** | Add the SPDX license identifier to source files |
-| **fix-workflows** | Set any unpinned actions to pinned shas |
 | **tasks** | Dry run all tasks in the base tasks file |
 
 ### [badge.yaml](./tasks/badge.yaml)

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -102,7 +102,9 @@ ignore: [] # an array of paths to ignore
 | **oscal** | Run linting checks on OSCAL |
 | **shell** | Run shellcheck on all Maru tasks, GitHub workflows, and local shell scripts |
 | **license** | Lint for the SPDX license identifier being in source files |
+| **workflows** | Lint for github workflows having their actions being pinned to a specific sha |
 | **fix-license** | Add the SPDX license identifier to source files |
+| **fix-workflows** | Set any unpinned actions to pinned shas |
 | **tasks** | Dry run all tasks in the base tasks file |
 
 ### [badge.yaml](./tasks/badge.yaml)

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -38,6 +38,7 @@ tasks:
       - task: shell
       - task: license
       - task: tasks
+      - task: workflows
 
   - name: yaml
     description: Run YAML linting checks
@@ -223,6 +224,47 @@ tasks:
           cmd="$ADDLICENSE_CMD -l \"$LICENSE\" $check_flag -s=only -v -c \"$COPYRIGHT\" ${ignore_flags[*]} . 2>/dev/null"
           echo "Running: $cmd"
           eval "$cmd"
+
+  - name: workflows
+    description: Lint GitHub workflows
+    actions:
+      - shell:
+          linux: bash
+          darwin: bash
+        cmd: |
+          for workflow in .github/workflows/*.yaml; do
+            # Call the StepSecurity API to process the workflow
+            response=$(curl -s 'https://prod.api.stepsecurity.io/v1/secure-workflow?addPermissions=false&addHardenRunner=false&' \
+              -X POST \
+              -H 'Content-Type: text/plain;charset=UTF-8' \
+              --data-binary "@$workflow")
+
+            EDITED=$(echo "$response" | jq -r .PinnedActions)
+            if [ "$EDITED" == "true" ]; then
+              echo 'Unpinned action shas for $workflow, please run `uds run lint:fix-workflows`'
+              exit 1
+            else
+              echo "No unpinned actions found in $workflow"
+            fi
+          done
+
+
+  - name: fix-workflows
+    description: Fix unpinned actions in GitHub workflows
+    actions:
+      - shell:
+          linux: bash
+          darwin: bash
+        cmd: |
+          for workflow in .github/workflows/*.yaml; do
+            # Call the StepSecurity API to process the workflow
+            response=$(curl -s 'https://prod.api.stepsecurity.io/v1/secure-workflow?addPermissions=false&addHardenRunner=false&' \
+              -X POST \
+              -H 'Content-Type: text/plain;charset=UTF-8' \
+              --data-binary "@$workflow")
+
+            echo "$response" | jq -j .FinalOutput > "$workflow"
+          done
 
   - name: fix-license
     description: Add the SPDX license identifier to source files

--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -38,7 +38,6 @@ tasks:
       - task: shell
       - task: license
       - task: tasks
-      - task: workflows
 
   - name: yaml
     description: Run YAML linting checks
@@ -239,7 +238,7 @@ tasks:
               -H 'Content-Type: text/plain;charset=UTF-8' \
               --data-binary "@$workflow")
 
-            EDITED=$(echo "$response" | jq -r .PinnedActions)
+            EDITED=$(echo "$response" | ./uds zarf tools yq -p=json '.PinnedActions')
             if [ "$EDITED" == "true" ]; then
               echo 'Unpinned action shas for $workflow, please run `uds run lint:fix-workflows`'
               exit 1
@@ -263,7 +262,7 @@ tasks:
               -H 'Content-Type: text/plain;charset=UTF-8' \
               --data-binary "@$workflow")
 
-            echo "$response" | jq -j .FinalOutput > "$workflow"
+            echo "$response" | ./uds zarf tools yq -p=json '.FinalOutput | trim' > "$workflow"
           done
 
   - name: fix-license


### PR DESCRIPTION
## Description

Use the step security api ([website that can be used manually](https://app.stepsecurity.io/secure-workflow)) to check for and pin actions to shas

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
