### PR TITLE
feat: add ignored_version input to republish task

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -78,6 +78,7 @@ tasks:
           git reset --hard HEAD
 
           # Get the latest tag matching the FLAVOR pattern
+          # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             REPUBLISH_TAG=$(git tag --list "*-${{ .inputs.flavor }}" --sort=-v:refname | head -n 1)
           else

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -50,6 +50,9 @@ tasks:
       flavor:
         description: The flavor of the package to publish
         default: ${FLAVOR}
+      ignored_versions:
+        description: Regex for versions to ignore (used by filter logic), useful when version scheme has changed and automatic sorting is not pulling the latest version
+        default: ""
     actions:
       - description: Remove copied repo
         cmd: rm -rf recreate-test
@@ -75,7 +78,11 @@ tasks:
           git reset --hard HEAD
 
           # Get the latest tag matching the FLAVOR pattern
-          REPUBLISH_TAG=$(git tag --list "*-${{ .inputs.flavor }}" --sort=-v:refname | head -n 1)
+          if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
+            REPUBLISH_TAG=$(git tag --list "*-${{ .inputs.flavor }}" --sort=-v:refname | head -n 1)
+          else
+            REPUBLISH_TAG=$(git tag --list "*-${{ .inputs.flavor }}" --sort=-v:refname | grep -v "${{ .inputs.ignored_versions }}" | head -n 1)
+          fi
 
           # Checkout the tag if it exists
           if [[ -n "$REPUBLISH_TAG" ]]; then


### PR DESCRIPTION
## Description

Adds a way to ignore a version in the republish workflow. 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
