### PR TITLE
feat: allow publish path to be set by the user

### DIFF
--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -12,6 +12,7 @@ variables:
   - name: ENABLE_UDS_PK
     default: "false"
   - name: BASE_REPO
+  - name: PUBLISH_PATH
 
 tasks:
   - name: package
@@ -72,6 +73,7 @@ tasks:
         with:
           team: ${{ .variables.TEAM }}
           base_repo: ${{ .variables.BASE_REPO }}
+          publish_path: ${{ .variables.PUBLISH_PATH }}
       - description: Get the current Zarf package name
         cmd: cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name
         setVariables:
@@ -101,6 +103,7 @@ tasks:
         with:
           team: ${{ .variables.TEAM }}
           base_repo: ${{ .variables.BASE_REPO }}
+          publish_path: ${{ .variables.PUBLISH_PATH }}
       - description: Get the current Zarf package name
         cmd: cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name
         setVariables:
@@ -141,6 +144,7 @@ tasks:
         with:
           team: ${{ .variables.TEAM }}
           base_repo: ${{ .variables.BASE_REPO }}
+          publish_path: ${{ .variables.PUBLISH_PATH }}
       - description: Get the current Zarf package name
         cmd: cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name
         setVariables:
@@ -168,6 +172,7 @@ tasks:
       - task: utils:determine-repo
         with:
           base_repo: ${{ .variables.BASE_REPO }}
+          publish_path: ${{ .variables.PUBLISH_PATH }}
       - description: Get the current UDS Bundle name
         cmd: cat ${{ .inputs.path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name
         setVariables:

--- a/tasks/utils.yaml
+++ b/tasks/utils.yaml
@@ -22,6 +22,9 @@ tasks:
       snapshot:
         description: Whether this is a snapshot release
         default: "false"
+      publish_path:
+        description: Publish path override
+        default: ""
     actions:
       - description: Determine repository for the given flavor/type of release
         cmd: |
@@ -30,6 +33,13 @@ tasks:
             echo "$TARGET_REPO"
             exit 0
           fi
+
+          if [ -n "${{ .inputs.publish_path }}" ]; then
+            repo="${{ .inputs.base_repo }}/${{ .inputs.publish_path }}"
+            echo "${repo}"
+            exit 0
+          fi
+
           repo="${{ .inputs.base_repo }}"
           # unicorn flavor = private repository
           if [ "${{ .inputs.flavor }}" = "unicorn" ]; then

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -23,6 +23,8 @@ spec:
       default: "true"
     mirror-project-id:
       default: ${MIRROR_PROJECT_ID}
+    publish-path:
+      default: ""
 ---
 publish:
   variables:
@@ -80,6 +82,10 @@ publish:
 
         if [[ -n "$[[ inputs.base-repo ]]" ]]; then
           ARGS+=(--set BASE_REPO="$[[ inputs.base-repo ]]")
+        fi
+
+        if [[ -n "$[[ inputs.publish-path ]]" ]]; then
+          ARGS+=(--set PUBLISH_PATH="$[[ inputs.publish-path ]]")
         fi
 
         if [[ -n "$[[ inputs.team ]]" ]]; then


### PR DESCRIPTION
## Description
Adds a `publish-path` input to [`utils:determine-repo`](https://github.com/defenseunicorns/uds-common/blob/e84f5624ec53b7e126166ae4d9f1144ba8afeac6/tasks/utils.yaml#L10-L54) that will ignore the existing path building logic and use the user-set value as a path for publishing.

A limitation of the current approach is that [GitLab container registry allows a maximum depth of two in the publish path](https://docs.gitlab.com/user/packages/container_registry/#naming-convention-for-your-container-images). The current implementation works great on upstream and registry1 variants as they are published to `/uds/mypackage`, but publishes of unicorn flavors are published to `/uds/private/mypackage`, which does not comply with GitLab's naming convention resulting in a 401 when publishing.

The `publish-path` input allows the user to set their own publish path to overcome this limitation.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
