### PR TITLE
fix: broken task reference in callable-publish workflow

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Publish Packages/Bundles - release-please
         if: ${{ steps.parse-inputs.outputs.uds-pk == 'false' }}
         run: |
-          if uds run --list | grep -q 'publish-package'; then
+          if uds run --list | grep -wq 'publish-package'; then
             uds run publish-package --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
           else
             uds run publish-release --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
@@ -99,7 +99,7 @@ jobs:
         run: |
           if uds-pk release check "${{ inputs.flavor }}"; then
             uds-pk release update-yaml ${{ inputs.flavor }}
-            if uds run --list | grep -q 'publish-package'; then
+            if uds run --list | grep -wq 'publish-package'; then
               uds run publish-package \
                 --set USE_CHECKPOINT=false \
                 --set FLAVOR=${{ inputs.flavor }} \


### PR DESCRIPTION
## Description
It appears that the recent addition of the `republish-package` task to the `tasks.yaml` file in the root of this repo has unintentionally caused `uds run package-publish` to be triggered in the release workflow on this repo - this fails because the task does not exist in this repo. This is currently [blocking](https://github.com/defenseunicorns/uds-common/actions/runs/14625947580/job/41037331338) the release workflow. 

This PR updates the regular expression for checking for the `publish-package` task to match exact matches only.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
