### PR TITLE
fix: make test artifact names more unique

### DIFF
--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -96,7 +96,10 @@ jobs:
 
       - name: Generate unique suffix
         id: uniq
-        run: echo "suffix=${RANDOM}" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          # shellcheck disable=SC3028
+          echo "suffix=${RANDOM}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}


### PR DESCRIPTION
## Description

add a step in the callable-test workflow to generate and append a unique suffix to the artifact upload names to prevent conflicts

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
