### PR TITLE
chore: ignore eslint.config.mjs

### DIFF
--- a/.license_config.yaml
+++ b/.license_config.yaml
@@ -1,4 +1,4 @@
 license: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 copyright: Defense Unicorns
 ignore:
-- eslint.config.mjs
+  - eslint.config.mjs

--- a/.license_config.yaml
+++ b/.license_config.yaml
@@ -1,3 +1,4 @@
 license: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 copyright: Defense Unicorns
-ignore: []
+ignore:
+- eslint.config.mjs


### PR DESCRIPTION
## Description

ESLint released a breaking change in v9.x which forced Pepr to also make a breaking change in order to update ESLint. Version 9.x of ESLint is configured differently and no longer use JSON files, instead now it is a `eslint.config.mjs`. 

We want to get ahead of any trouble in UDS Core and feel 💯 confident that this feature will not have impact on the product before the release so we are doing some testing on the nightly release of Pepr.

The problem is that the `addlicense` tool is [timing out after 0](https://github.com/defenseunicorns/uds-core/actions/runs/15022736270/job/42215747267?pr=1564#step:3:156) seconds on the new `eslint.config.mjs` in UDS Core CI.

Based on this error I would like to propose adding `eslint.config.mjs` to the ignored array.

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
