### PR TITLE
fix: export auth env var before all uds run steps

### DIFF
--- a/.github/workflows/callable-lint.yaml
+++ b/.github/workflows/callable-lint.yaml
@@ -35,14 +35,17 @@ jobs:
 
       - name: Environment setup
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           uds run actions:setup-environment \
           --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Install lint deps
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           uds run lint:deps --no-progress
 
       - name: Lint the repository
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           uds run lint:all --no-progress

--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Environment setup
         run: |
+            export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
             uds run actions:setup-environment \
             --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
@@ -86,6 +87,7 @@ jobs:
       - name: Publish Packages/Bundles - release-please
         if: ${{ steps.parse-inputs.outputs.uds-pk == 'false' }}
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           if uds run --list | grep -wq 'publish-package'; then
             uds run publish-package --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
           else
@@ -97,6 +99,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           if uds-pk release check "${{ inputs.flavor }}"; then
             uds-pk release update-yaml ${{ inputs.flavor }}
             if uds run --list | grep -wq 'publish-package'; then

--- a/.github/workflows/callable-republish-package.yaml
+++ b/.github/workflows/callable-republish-package.yaml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Environment setup
         run: |
+            export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
             uds run actions:setup-environment \
             --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
@@ -64,16 +65,21 @@ jobs:
 
       - name: Republish the package
         run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
           uds run republish-package --set USE_CHECKPOINT=false --set FLAVOR=${{ inputs.flavor }} --no-progress ${{ inputs.options }}
 
       - name: Debug Output
         if: ${{ always() }}
-        run: uds run actions:debug-output
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:debug-output
         shell: bash
 
       - name: Save logs
         if: ${{ always() }}
-        run: uds run actions:save-logs
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:save-logs
         shell: bash
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -198,6 +198,7 @@ jobs:
 
       - name: Environment setup
         run: |
+            export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
             uds run actions:setup-environment \
             --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
@@ -242,7 +243,9 @@ jobs:
           version: v${{ inputs.udsCliVersion }}
 
       - name: Environment setup
-        run: uds run actions:install-deps
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:install-deps
         shell: bash
 
       - name: Download sbom scan results from GitHub Actions Artifacts

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -64,34 +64,45 @@ jobs:
       - name: Clean Runner
         # If we are on ubuntu-latest we should try to clean the disk since it is the thing that is most limiting
         if: ${{ inputs.runsOn == 'ubuntu-latest' }}
-        run: uds run actions:clean-gh-runner
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:clean-gh-runner
         shell: bash
 
       - name: Environment setup
         run: |
-            uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:setup-environment \
+          --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+          --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+          --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+          --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
       - name: Test
-        run: uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}" --set OPTIONS="${{ inputs.options }}"
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:test-deploy --set FLAVOR="${{ inputs.flavor }}" --set TYPE="${{ inputs.type }}" --set OPTIONS="${{ inputs.options }}"
         shell: bash
 
       - name: UDS Badge Verification
-        run: uds run actions:verify-badge
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:verify-badge
         shell: bash
 
       - name: Debug Output
         if: ${{ always() }}
-        run: uds run actions:debug-output
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:debug-output
         shell: bash
 
       - name: Save logs
         if: ${{ always() }}
-        run: uds run actions:save-logs
+        run: |
+          export MARU_AUTH="{\"raw.githubusercontent.com\": \"$(gh auth token)\"}"
+          uds run actions:save-logs
         shell: bash
 
       - name: Generate unique suffix


### PR DESCRIPTION
## Description

github is now ratelimiting unauthenticated requests which i causing lots of CI failures. 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
