### PR TITLE
fix: add additional auth setup in callable test workflow

### DIFF
--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Environment setup
         run: |
+          echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
           uds run actions:setup-environment \
           --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
           --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \


### PR DESCRIPTION
## Description

The previous PR that added authentication for `uds run` to overcome the GitHub rate-limiting on unauthenticated requests missed one location where the authentication is needed. This PR adds that additional auth setup command in callable test workflow

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
