### PR TITLE
feat: add gitlab registry auth config to gitlab templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ insecure*
 zarf
 tmp-tasks.yaml
 upgrade-test/
+.vscode/

--- a/templates/deploy.yml
+++ b/templates/deploy.yml
@@ -7,6 +7,10 @@ spec:
     environment:
     runs-on:
       default: gitlab-runner-4c-amd64
+    ci-registry-user:
+      default: ${CI_REGISTRY_USER}
+    ci-registry-password:
+      default: ${CI_REGISTRY_PASSWORD}
     registry1-username:
       default: ${IRON_BANK_ROBOT_USERNAME}
     registry1-password:
@@ -23,8 +27,8 @@ deploy:$[[ inputs.environment ]]:
                                               --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
                                               --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
-                                              --set GITLAB_REGISTRY_USER="$CI_REGISTRY_USER" \
-                                              --set GITLAB_REGISTRY_TOKEN="$CI_REGISTRY_PASSWORD" \
+                                              --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
+                                              --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \
                                               --set GHCR_REGISTRY_USER="$GH_USER_READ_ONLY" \
                                               --set GHCR_REGISTRY_TOKEN="$GH_PAT_READ_ONLY"
     # Create package

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -9,6 +9,10 @@ spec:
       default: .ci_artifacts
     reports-path:
       default: ""
+    ci-registry-user:
+      default: ${CI_REGISTRY_USER}
+    ci-registry-password:
+      default: ${CI_REGISTRY_PASSWORD}
     registry1-username:
       default: ${IRON_BANK_ROBOT_USERNAME}
     registry1-password:
@@ -48,8 +52,8 @@ publish:
                                               --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
                                               --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
-                                              --set GITLAB_REGISTRY_USER="$CI_REGISTRY_USER" \
-                                              --set GITLAB_REGISTRY_TOKEN="$CI_REGISTRY_PASSWORD" \
+                                              --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
+                                              --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \
                                               --set GHCR_REGISTRY_USER="$GH_USER_READ_ONLY" \
                                               --set GHCR_REGISTRY_TOKEN="$GH_PAT_READ_ONLY"
 

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -10,6 +10,10 @@ spec:
       default: .ci_artifacts
     reports-path:
       default: ""
+    ci-registry-user:
+      default: ${CI_REGISTRY_USER}
+    ci-registry-password:
+      default: ${CI_REGISTRY_PASSWORD}
     registry1-username:
       default: ${IRON_BANK_ROBOT_USERNAME}
     registry1-password:
@@ -64,8 +68,8 @@ test:
                                               --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
                                               --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
-                                              --set GITLAB_REGISTRY_USER="$CI_REGISTRY_USER" \
-                                              --set GITLAB_REGISTRY_TOKEN="$CI_REGISTRY_PASSWORD" \
+                                              --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
+                                              --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \
                                               --set GHCR_REGISTRY_USER="$GH_USER_READ_ONLY" \
                                               --set GHCR_REGISTRY_TOKEN="$GH_PAT_READ_ONLY"
     - uds run actions:test-deploy --set FLAVOR="$[[ inputs.flavor ]]" --set TYPE="$[[ inputs.type ]]" --set OPTIONS="$[[ inputs.options ]]"


### PR DESCRIPTION
## Description
Need to be able to configure a different token to use for gitlab registry auth. In some cases the use of the job token isn't sufficient. 

