### PR TITLE
chore: install addlicense to /home/maciej/workspace/unicorns/bin just like all the other go tools

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -28,7 +28,7 @@ tasks:
         cmd: pipx install "yamllint>=1.30.0"
       - description: Install addlicense via go
         # renovate: datasource=github-tags depName=google/addlicense versioning=semver
-        cmd: GOPATH="$HOME/go" go install github.com/google/addlicense@v1.1.1
+        cmd: go install github.com/google/addlicense@v1.1.1
 
   - name: all
     description: Run all linting commands
@@ -191,10 +191,10 @@ tasks:
           # Check for addlicense binary. Look in $PATH first with fallback to $HOME/go/bin
           if command -v addlicense >/dev/null 2>&1; then
             ADDLICENSE_CMD="addlicense"
-          elif [ -x "$HOME/go/bin/addlicense" ]; then
-            ADDLICENSE_CMD="$HOME/go/bin/addlicense"
+          elif [ -x "$(go env GOPATH)/bin/addlicense" ]; then
+            ADDLICENSE_CMD="$(go env GOPATH)/bin/addlicense"
           else
-            echo "Error: addlicense is not found in PATH or in $HOME/go/bin" >&2
+            echo "Error: addlicense is not found in PATH or in GOPATH/bin" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Description
In multiple places, see [here](https://github.com/defenseunicorns/uds-registry/blob/3d8a80fe62b1638c73d4f867f5684fb25a449106/tasks/lint.yaml#L36-L46) and [here](https://github.com/defenseunicorns/uds-multicluster/blob/fdb4253e1da0b352fa11595cfdce982362bd9a9f/tasks/lint.yaml#L25-L32) we are working around the usual installation path for addlicense from being just `$GOPATH/bin` to being `$HOME/bin/go`. 

The former is standard in the [go world ](https://go.dev/wiki/GOPATH#gopath-variable) so I'm proposing we stop using this "hack" and just align with all the tooling :sweat_smile: 


## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
