### PR TITLE
fix: remove arm restriction on registry1 tasks

### DIFF
--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -24,13 +24,7 @@ tasks:
     actions:
       - env:
           - ZARF_CONFIG=${{ .inputs.config }}
-        cmd: |
-          if [ "${FLAVOR}" != "registry1" ] || [ "${{ .inputs.architecture }}" != "arm64" ]; then
-            ./uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" --flavor "${FLAVOR}" ${{ .inputs.options }}
-          else
-            echo "Registry1 packages cannot be made for 'arm64'"
-            exit 1
-          fi
+        cmd: ./uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" --flavor "${FLAVOR}" ${{ .inputs.options }}
 
   - name: recreate-latest-tag-package
     description: Recreate the UDS Zarf Package in the repository
@@ -95,12 +89,7 @@ tasks:
 
           uds-pk release update-yaml ${{ .inputs.flavor }}
 
-          if [ "${FLAVOR}" != "registry1" ] || [ "${{ .inputs.architecture }}" != "arm64" ]; then
-            ./uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" --flavor "${FLAVOR}" ${{ .inputs.options }}
-          else
-            echo "Registry1 packages cannot be made for 'arm64'"
-            exit 1
-          fi
+          ./uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" --flavor "${FLAVOR}" ${{ .inputs.options }}
 
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           LOCAL_VERSION=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.version)
@@ -130,9 +119,4 @@ tasks:
     actions:
       - env:
           - UDS_CONFIG=${{ .inputs.config }}
-        cmd: |
-          if [ "${FLAVOR}" != "registry1" ] || [ "${{ .inputs.architecture }}" != "arm64" ]; then
-            ./uds create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" ${{ .inputs.options }}
-          else
-            echo "Registry1 bundles cannot be made for 'arm64'"
-          fi
+        cmd: ./uds create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" ${{ .inputs.options }}

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -97,21 +97,14 @@ tasks:
           # Run any dependency commands (i.e. uds run dependencies:create)
           sh -c "${{ .inputs.dep_commands }}"
 
-          # Checks if the zarf package is registry1 and ARM
-          if [ "${FLAVOR}" != "registry1" ] || [ "${{ .inputs.architecture }}" != "arm64" ]; then
+          # Creates and moves the bundle into the correct spot
+          ./uds create ${{ .inputs.bundle_path }} \
+            --architecture=${{ .inputs.architecture }} \
+            --confirm \
+            --no-progress \
+            ${{ .inputs.options }}
 
-            # Creates and moves the bundle into the correct spot
-            ./uds create ${{ .inputs.bundle_path }} \
-              --architecture=${{ .inputs.architecture }} \
-              --confirm \
-              --no-progress \
-              ${{ .inputs.options }}
-
-            mv "${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${PREVIOUS_BUNDLE_VERSION}.tar.zst" "../${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${BUNDLE_VERSION}.tar.zst"
-          else
-            echo "::warning::⚠️ Registry1 bundles cannot be made for 'arm64'"
-            exit 1
-          fi
+          mv "${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${PREVIOUS_BUNDLE_VERSION}.tar.zst" "../${{ .inputs.bundle_path }}/uds-bundle-${BUNDLE_NAME}-${{ .inputs.architecture }}-${BUNDLE_VERSION}.tar.zst"
 
       - description: Remove the upgrade-test folder
         cmd: rm -rf upgrade-test


### PR DESCRIPTION
## Description

UDS Core has the full collection of images required for ARM registry1 builds. This removes the task arch restriction to enable consumption of these tasks for arm registry1 builds.

Note that I did not adjust the workflows so there may still be matrix workflow restrictions in place which are probably wise to keep for the general package use case.

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
