### PR TITLE
fix: add error check for keycloak admin token creation

### DIFF
--- a/tasks/setup.yaml
+++ b/tasks/setup.yaml
@@ -141,6 +141,10 @@ tasks:
             --data-urlencode "password=${KEYCLOAK_ADMIN_PASSWORD}" \
             --data-urlencode "client_id=admin-cli" \
             --data-urlencode "grant_type=password" | ./uds zarf tools yq .access_token)
+          if [ -z "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" ] || [ "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" = "null" ]; then
+            echo "Error: Failed to obtain KEYCLOAK_ADMIN_ACCESS_TOKEN"
+            exit 1
+          fi
 
           # Create a Keycloak User in the UDS Realm
           curl -s --location "https://keycloak.admin.uds.dev/admin/realms/uds/users" \


### PR DESCRIPTION
## Description

Added simple error check to catch failures getting KEYCLOAK_ADMIN_ACCESS_TOKEN
...

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
