### PR TITLE
feat: lint tasks with required inputs

### DIFF
--- a/tasks/lint.yaml
+++ b/tasks/lint.yaml
@@ -236,10 +236,36 @@ tasks:
     actions:
       - description: Dry run tasks
         cmd: |
-          tasks=$(./uds run --list=md | tail -n +3 | awk -F '|' '{gsub("\\*\\*", "", $2); print $2}')
-
-          # Loop through each command and execute with --dry-run
-          for task in $tasks; do
-            printf "\n\033[0;36mChecking '\033[1;33m%s\033[0;36m' with --dry-run\033[0m\n" "$task"
-            ./uds run "$task" --dry-run
+          for task_file in tasks.yaml tasks/*.yaml; do
+            printf "\n\033[1;35mChecking tasks in %s\033[0m\n" "$task_file"
+            tasks=$(./uds run -f "$task_file" --list=md | tail -n +3 | awk -F '|' '{gsub("\\*\\*", "", $2); print $2}')
+            # Loop through each command and execute with --dry-run
+            echo "$tasks" | while read -r task; do
+              [ -z "$task" ] && continue
+              printf "\n\033[0;36mChecking '\033[1;33m%s\033[0;36m' with --dry-run\033[0m\n" "$task"
+              # Check for required inputs and display them if found
+              required_inputs=$(./uds zarf t yq '.tasks[] | select(.name == "'"$task"'") | .inputs | to_entries[] | select(.value.required == true) | .key' $task_file)
+              # Use a different approach to avoid subshell variable scope issues
+              if [[ -n "$required_inputs" ]]; then
+                printf "\033[1;33mRequired inputs for %s:\033[0m\n" "$task"
+                
+                # Build the dry run args string without using a pipe
+                dry_run_args=""
+                for input in $required_inputs; do
+                  [[ -z "$input" ]] && continue
+                  printf "  - \033[0;36m%s\033[0m\n" "$input"
+                  dry_run_args="${dry_run_args} --with $input=dry-run"
+                done
+                
+                if [[ -n "$dry_run_args" ]]; then
+                  echo "Dry run args:$dry_run_args"
+                fi
+              fi
+              
+              # Run the task with any dry run args
+              ./uds run -f "$task_file" "$task" $dry_run_args --dry-run
+            done
           done
+        shell:
+          linux: bash
+          darwin: bash


### PR DESCRIPTION
## Description

Support linting tasks with required inputs.

```
     Checking 'test-lint' with --dry-run                                                                                                                                         
     Required inputs for test-lint:                                                                                                                                              
       - test-input                                                                                                                                                              
     Dry run args: --with test-input=dry-run                                                                                                                                     
     echo foo      
```

