### PR TITLE
chore: add markdown file extension to renovate matches

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -134,7 +134,8 @@
         {
             "customType": "regex",
             "fileMatch": [
-                ".*\\.ya?ml$"
+                ".*\\.ya?ml$",
+                ".*\\.md$"
             ],
             "matchStrings": [
                 // Test: https://regex101.com/r/d9t0lt/1
@@ -151,6 +152,7 @@
             "fileMatch": [
                 ".*\\.ya?ml$",
                 ".*\\.sh$",
+                ".*\\.md$",
                 ".*\\.?Dockerfile$"
             ],
             "matchStrings": [
@@ -166,7 +168,8 @@
         {
             "customType": "regex",
             "fileMatch": [
-                ".*\\.ya?ml$"
+                ".*\\.ya?ml$",
+                ".*\\.md$"
             ],
             "matchStrings": [
                 // Test: https://regex101.com/r/p3Cpjx/2


### PR DESCRIPTION
## Description

Adds markdown extension to the file matches for places where markdown comments are supported (i.e. `<!--`).

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
