### PR TITLE
chore: add LICENSE_KEY to publish flow

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -34,6 +34,9 @@ on:
         type: boolean
         default: false
         description: "DEPRECATED: Whether to use the UDS Releaser for publishing"
+    secrets:
+      LICENSE_KEY:
+        required: false
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -106,13 +109,15 @@ jobs:
                 --set USE_CHECKPOINT=false \
                 --set FLAVOR=${{ inputs.flavor }} \
                 --set ENABLE_UDS_PK=true \
-                --no-progress ${{ inputs.options }}
+                --no-progress ${{ inputs.options }} \
+                --set LICENSE_KEY=${{ secrets.LICENSE_KEY }}
             else
               uds run publish-release \
                 --set USE_CHECKPOINT=false \
                 --set FLAVOR=${{ inputs.flavor }} \
                 --set ENABLE_UDS_PK=true \
-                --no-progress ${{ inputs.options }}
+                --no-progress ${{ inputs.options }} \
+                --set LICENSE_KEY=${{ secrets.LICENSE_KEY }}
             fi
           fi
 


### PR DESCRIPTION
## Description

- Allow the setting of LICENSE_KEY variable to the publish flow. 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
