### PR TITLE
fix: add sanitization of colons in scan action artifact upload

### DIFF
--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -189,6 +189,7 @@ jobs:
         run: |
           NAME=$(jq -r '.metadata.component.name + "@" + .metadata.component.version' ${{ steps.scan.outputs.cyclonedx-json }})
           NAME="${NAME//\//_}"
+          NAME="${NAME//:/_}"
           NAME="${NAME/docker.io_library_/}"
           mv ${{ steps.scan.outputs.cyclonedx-json }} "${NAME}.json"
           echo "artifactName=${NAME}" >> "$GITHUB_OUTPUT"
@@ -239,6 +240,7 @@ jobs:
         run: |
           NAME=$(jq -r '.metadata.component.name + "@" + .metadata.component.version' ${{ steps.scan.outputs.cyclonedx-json }})
           NAME="${NAME//\//_}"
+          NAME="${NAME//:/_}"
           NAME="${NAME/docker.io_library_/}"
           mv ${{ steps.scan.outputs.cyclonedx-json }} "${NAME}.json"
           echo "artifactName=${NAME}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

Ran into an issue where colons (`:`) are not being sanitized from the scan images github artifacts when uploaded.  See reference error: https://github.com/uds-packages/neuvector/actions/runs/17775044232/job/50520551604?pr=2#step:7:11

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
