### PR TITLE
ci: create PR to bump releaser

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -1,9 +1,11 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-name: Auto Update
+# EXPERIMENTAL
+# This workflow is not yet ready for production use.
+# This is currently being tested by the UDS Foundry team.
 
-# Testing call conditions, this will be a schedule
+name: Auto Update
 
 on:
   schedule:

--- a/.github/workflows/callable-auto-update.yaml
+++ b/.github/workflows/callable-auto-update.yaml
@@ -146,7 +146,7 @@ jobs:
           BASE_BRANCH: ${{ github.head_ref || github.ref_name }}
           COMMIT_MSG: "chore(republish): update due to updated source images"
           PR_TITLE: "chore(republish): update releaser.yaml to republish images"
-          PR_BODY: Automated update of releaser.yaml due to updated source images.
+          PR_BODY: "EXPERIMENTAL PR: Automated update of releaser.yaml due to updated source images."
           PR_LABEL: republish
         run: |
           # This job will create a PR to update the version in releaser.yaml, by doing the following:


### PR DESCRIPTION
## Description
- This modification to the republish job is related to this issue: https://github.com/uds-packages/maintenance/issues/59#issuecomment-3720988810

- The above issue should have more detail, but the TLDR is that the initial implementation was trying to merge straight to main and branch protections would not allow that. This new workflow will instead create a new branch, with a label, and push those changes to the branch. 
- We then have a daily workflow in the `maintenance` repo that will approve and merge the PR in if all the status checks are passing.

## Testing
Both of the below tests have a workflow called `auto-update.yaml`, which is pointing at this current branch of `uds-common`

#### No Changes Required
- There is no difference in the upstream images and the images we have published, so nothing happens: https://github.com/uds-packages/dummy/actions/runs/20795212938

#### PR Created
- There is a difference in the upstream images and the images we have published, [so the workflow runs](https://github.com/uds-packages/adminer/actions/runs/20797474126/job/59734632498). A new PR is [created from the workflow](https://github.com/uds-packages/adminer/pull/69)

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
