### PR TITLE
feat: re-runnable callable publish

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -6,6 +6,14 @@ name: Callable-Publish
 on:
   workflow_call:
     inputs:
+      arch:
+        description: The architecture to publish for; arm64, amd64, etc.
+        required: true
+        type: string
+      base-repo:
+        description: The base repository to publish to
+        required: true
+        type: string
       runsOn:
         default: ubuntu-latest
         type: string
@@ -113,7 +121,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if uds-pk release check "${{ inputs.flavor }}"; then
+          if uds-pk release check "${{ inputs.flavor }}" --arch "${{ inputs.arch }}" --base-repo "${{ inputs.base-repo }}" --verbose; then
             uds-pk release update-yaml ${{ inputs.flavor }}
             if uds run --list | grep -wq 'publish-package'; then
               uds run publish-package \

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -127,7 +127,7 @@ tasks:
       - description: Install uds-pk
         env:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-pk versioning=semver-coerced
-          - UDS_PK_VERSION=v0.1.2
+          - UDS_PK_VERSION=v0.1.3
         cmd: |
           echo "Installing uds-pk version $UDS_PK_VERSION"
           curl -o /usr/local/bin/uds-pk -L \


### PR DESCRIPTION
The PR fixes issues with rerunning a partially successful release.
To achieve that, it adds two required arguments to the callable-publish.yaml:
* `arch` - architecture, e.g. arm64, amd64
* `base-repo`, e.g. ghcr.io/uds-packages

Example of changed invocation:

```yaml
    with:
      flavor: ${{ matrix.flavor }}
      options: --set BASE_REPO="ghcr.io/uds-packages"
      runsOn: ${{ matrix.architecture == 'arm64' && 'appstore-8-core-arm64' || 'appstore-8-core-amd64' }}
      uds-releaser: true
      arch: ${{ matrix.architecture }}
      base-repo: ghcr.io/uds-packages
```