### PR TITLE
feat: callable-publish figuring out organization/base-repo

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -111,24 +111,30 @@ jobs:
 
           # Compute arch output: use provided input when set, otherwise derive from runner.arch
           if [ -n "${{ inputs.arch }}" ]; then
-            echo "arch=${{ inputs.arch }}" >> "$GITHUB_OUTPUT"
+            resolved_arch="${{ inputs.arch }}"
           else
             # Map runner.arch (X64, ARM64) to expected values (amd64, arm64)
             case "${{ runner.arch }}" in
-              X64)   echo "arch=amd64" >> "$GITHUB_OUTPUT" ;;
-              ARM64) echo "arch=arm64" >> "$GITHUB_OUTPUT" ;;
-              *)     echo "arch=${{ runner.arch }}" >> "$GITHUB_OUTPUT" ;;
+              X64)   resolved_arch="amd64" ;;
+              ARM64) resolved_arch="arm64" ;;
+              *)     resolved_arch="${{ runner.arch }}" ;;
             esac
           fi
+          echo "arch=${resolved_arch}" >> "$GITHUB_OUTPUT"
 
           # Compute base-repo output: use provided input when set, otherwise default to ghcr.io/<organization>
           if [ -n "${{ inputs.base-repo }}" ]; then
-            echo "base-repo=${{ inputs.base-repo }}" >> "$GITHUB_OUTPUT"
+            resolved_base_repo="${{ inputs.base-repo }}"
           else
             # Prefer GITHUB_REPOSITORY_OWNER if present, else parse GITHUB_REPOSITORY
             owner="${GITHUB_REPOSITORY_OWNER:-${GITHUB_REPOSITORY%%/*}}"
-            echo "base-repo=ghcr.io/${owner}" >> "$GITHUB_OUTPUT"
+            resolved_base_repo="ghcr.io/${owner}"
           fi
+          echo "base-repo=${resolved_base_repo}" >> "$GITHUB_OUTPUT"
+
+          # Debug output
+          echo "Resolved arch: ${resolved_arch}"
+          echo "Resolved base-repo: ${resolved_base_repo}"
 
       - name: Publish Packages/Bundles - release-please
         if: ${{ steps.parse-inputs.outputs.uds-pk == 'false' }}


### PR DESCRIPTION
## Description
Determining base repo and architecture automatically

## Tests
Tested on fider: https://github.com/uds-packages/fider/actions/runs/21009739458/job/60401415765?pr=82


<img width="846" height="59" alt="image" src="https://github.com/user-attachments/assets/5818c518-1ae7-4095-a812-a6ed1e59b032" />
