### PR TITLE
fix: remove prCreation from common renovate config

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -403,7 +403,6 @@
             ],
             "minimumReleaseAge": "3 days",
             "internalChecksFilter": "strict",
-            "prCreation": "not-pending",
             "minimumReleaseAgeBehaviour": "timestamp-required"
         }
     ]


### PR DESCRIPTION
## Description
Remove `prCreation: "not-pending"` from the `minimumReleaseAge` package rule as it creates an unsatisfiable condition. When combined with `internalChecksFilter: "strict"`, Renovate discounts its own internal `renovate/stability-days` check and waits for external CI that never runs on Renovate branches, permanently blocking PR creation. The `minimumReleaseAge: "3 days"` and `internalChecksFilter: "strict"` settings already provide the intended gating behavior on their own.

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
