### PR TITLE
fix: handle v prefix in tags for test-upgrade

### DIFF
--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -82,9 +82,9 @@ tasks:
           LOCAL_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq '.packages[] | select(.name == env(PACKAGE_NAME)) | .ref' | uniq )
           # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | sed 's/^v//' | sort -V | tail -1)
           else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${{ .inputs.flavor }}" | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${{ .inputs.flavor }}" | sed 's/^v//' | sort -V | tail -1)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)


### PR DESCRIPTION
## Description

Packages that have previously used a `v` prefix in their releases pull that version as the latest tag when setting `LATEST_VERSION` from the `zarf tools registry` command, while the `TAG` env variable in `test-upgrade` "Create test bundle of last tag" action correctly pulls the latest git tag that should be used for the Package. Adding a `sed` replacement in the command correctly handles the sorting when these tags are included, otherwise the latest tag with the `v` prefix always takes precedence over newer tags. 

[Example](https://github.com/uds-packages/argo-workflows/actions/runs/24407946648/job/71296426953#step:6:23) of downstream Package pulling in the wrong version of the Package when checking out the correct git tag.

[Example](https://github.com/uds-packages/argo-workflows/actions/runs/24413448960/job/71316256155?pr=171#step:6:23) of that same downstream package successfully pulling the latest tagged Package using the `upgrade` task file in the commit sha for this PR's commit. 

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
