### PR TITLE
fix: downgrade oras cli version

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
         with:
           # renovate: datasource=github-tags depName=oras-project/oras versioning=semver
-          version: 1.3.2
+          version: 1.3.1
 
       - name: Environment setup
         run: |


### PR DESCRIPTION
## Description

- Renovate bumped oras cli version to `1.3.2`, but the [setup task we use](https://github.com/oras-project/setup-oras/releases/tag/v2.0.0) only supports up to `1.3.1` currently


## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
