### PR TITLE
fix: pull oci artifact from proper tags

### DIFF
--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -80,7 +80,10 @@ tasks:
           PACKAGE_NAME=$(cat ${{ .inputs.path }}/zarf.yaml | ./uds zarf tools yq .metadata.name)
           export PACKAGE_NAME
           LOCAL_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq '.packages[] | select(.name == env(PACKAGE_NAME)) | .ref' | uniq )
-          # shellcheck disable=SC2157
+
+          # Latest tag for package/flavor. Strips tag, sorts, returns original.
+          # e.g. {1.5.0, v1.6.0, v1.5.1} -> v1.6.0
+          # else filters ignored_versions.
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | awk '{ orig=$0; sub(/^v/, "", $0); print $0"\t"orig }' | sort -V | tail -1 | cut -f2)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -82,9 +82,9 @@ tasks:
           LOCAL_VERSION=$(cat ../${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq '.packages[] | select(.name == env(PACKAGE_NAME)) | .ref' | uniq )
           # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | sed 's/^v//' | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | awk '{ orig=$0; sub(/^v/, "", $0); print $0"\t"orig }' | sort -V | tail -1 | cut -f2)
           else
-            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${{ .inputs.flavor }}" | sed 's/^v//' | sort -V | tail -1)
+            LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep -v "${{ .inputs.ignored_versions }}" | grep "${{ .inputs.flavor }}" | awk '{ orig=$0; sub(/^v/, "", $0); print $0"\t"orig }' | sort -V | tail -1 | cut -f2)
           fi
           BUNDLE_NAME=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.name)
           PREVIOUS_BUNDLE_VERSION=$(cat ${{ .inputs.bundle_path }}/uds-bundle.yaml | ./uds zarf tools yq .metadata.version)
@@ -98,7 +98,7 @@ tasks:
 
           # NOTE: This does not include the flavor suffix because the bundle will need to reference all flavors easily
           if [ ! -e "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst" ]; then
-            mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
+            mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION#v}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
           fi
 
           # Run any dependency commands (i.e. uds run dependencies:create)

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -84,6 +84,7 @@ tasks:
           # Latest tag for package/flavor. Strips tag, sorts, returns original.
           # e.g. {1.5.0, v1.6.0, v1.5.1} -> v1.6.0
           # else filters ignored_versions.
+          # shellcheck disable=SC2157
           if [[ -z "${{ .inputs.ignored_versions }}" ]]; then
             LATEST_VERSION=$(./uds zarf tools registry ls "${TARGET_REPO}/${PACKAGE_NAME}" | grep "${{ .inputs.flavor }}" | awk '{ orig=$0; sub(/^v/, "", $0); print $0"\t"orig }' | sort -V | tail -1 | cut -f2)
           else

--- a/tasks/upgrade.yaml
+++ b/tasks/upgrade.yaml
@@ -98,7 +98,7 @@ tasks:
 
           # NOTE: This does not include the flavor suffix because the bundle will need to reference all flavors easily
           if [ ! -e "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst" ]; then
-            mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION#v}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
+            mv "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LATEST_VERSION}.tar.zst" "${{ .inputs.path }}/zarf-package-${PACKAGE_NAME}-${{ .inputs.architecture }}-${LOCAL_VERSION}.tar.zst"
           fi
 
           # Run any dependency commands (i.e. uds run dependencies:create)


### PR DESCRIPTION
# Description

A recent change in UDS-Common #649 was introduced to fix sort ordering for packages published with a mix of `v`-prefixed and bare tags. That change inadvertently broke workflows for packages that publish with a `v` prefix, such as [cert-manager](https://github.com/uds-packages/cert-manager/blob/013de90b5596ec888e49e16b6669ec731327e19d/releaser.yaml#L7).

The [broken cert-manager workflow](https://github.com/uds-packages/cert-manager/actions/runs/25080300687/job/73483554593) shows the following failure from the previous fix:
- The OCI pull URL dropped the `v` prefix even though the published tag includes it (e.g. `v1.20.0-uds.1-registry1`), so the pull failed with OCI artifact found.

# Fix

Sort using the stripped tag, but keep the original tag for the OCI pull and tarball rename. Still handles the mixed-tag case from #649.

# Verified runs

- [cert-manager](https://github.com/uds-packages/cert-manager/actions/runs/25116357103/job/73608462515?pr=220) — now working - it has a `v`-prefixed package
- [argo-workflows](https://github.com/uds-packages/argo-workflows/actions/runs/25116393485/job/73604628750?pr=176) — still passing - this is the original package the previous 649 fix targeted


### Checklist before merging

- [x]  ADR proposed if making an architectural change to the repo
- [x]  Tests run, docs added or updated as needed