### PR TITLE
chore: add chainguard creds

### DIFF
--- a/.github/workflows/callable-auto-update-flavor.yaml
+++ b/.github/workflows/callable-auto-update-flavor.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name:
@@ -36,6 +36,7 @@ on:
 permissions:
   contents: write # Allows us to read files from the repository for scanning, and writing the bumped releaser.yaml if applicable.
   packages: read # Allows us to pull the sboms from the published packages for comparison.
+  id-token: write # Allows authentication to Chainguard via OIDC.
 
 jobs:
   # figure out location of package for current flavor and arch
@@ -65,7 +66,8 @@ jobs:
           --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
           --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
           --set RAPIDFORT_USERNAME="${{ secrets.RAPIDFORT_USERNAME }}" \
-          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}"
+          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}" \
+          --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
       - name: Scan SBOMs and compare digests to upstream images

--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name: Callable-Publish
@@ -93,7 +93,8 @@ jobs:
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
             --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             --set RAPIDFORT_USERNAME="${{ secrets.RAPIDFORT_USERNAME }}" \
-            --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}"
+            --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}" \
+            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
       - name: Parse inputs

--- a/.github/workflows/callable-republish-package.yaml
+++ b/.github/workflows/callable-republish-package.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name: Callable-Republish-Package
@@ -61,7 +61,8 @@ jobs:
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
             --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             --set RAPIDFORT_USERNAME="${{ secrets.RAPIDFORT_USERNAME }}" \
-            --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}"
+            --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}" \
+            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
       - name: Republish the package

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name: Callable-Scan
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: read # Allows reading the content of the repository.
   packages: read # Allows reading the content of the repository's packages.
+  id-token: write # Allows authentication to Chainguard via OIDC.
   pull-requests: write # Allows writing the scan results comment to the pull request.
 
 # Abort prior jobs in the same workflow / PR
@@ -57,7 +58,8 @@ jobs:
           --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
           --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
           --set RAPIDFORT_USERNAME="${{ secrets.RAPIDFORT_USERNAME }}" \
-          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}"
+          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}" \
+          --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
 
           uds run actions:install-deps
         shell: bash

--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 name: Callable-Test
@@ -149,7 +149,8 @@ jobs:
           --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
           --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
           --set RAPIDFORT_USERNAME="${{ secrets.RAPIDFORT_USERNAME }}" \
-          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}"
+          --set RAPIDFORT_PASSWORD="${{ secrets.RAPIDFORT_PASSWORD }}" \
+          --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
       - name: Test

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 variables:
@@ -21,6 +21,10 @@ variables:
   - name: RAPIDFORT_USERNAME
     default: ""
   - name: RAPIDFORT_PASSWORD
+    default: ""
+  - name: CHAINGUARD_IDENTITY
+    default: ""
+  - name: CHAINGUARD_TOKEN
     default: ""
   - name: CHART_PATH
     default: chart/
@@ -152,6 +156,32 @@ tasks:
           registry: quay.io
           registry_username: ${{ .variables.RAPIDFORT_USERNAME }}
           registry_token: ${{ .variables.RAPIDFORT_PASSWORD }}
+
+      - description: Chainguard Login
+        if: ${{ ne .variables.CHAINGUARD_IDENTITY "" }}
+        cmd: |
+          if [ -z "$GITLAB_CI" ]; then
+            curl -o /usr/local/bin/chainctl -L \
+            "https://dl.enforce.dev/chainctl/latest/chainctl_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/aarch64/arm64/')" \
+            && chmod +x /usr/local/bin/chainctl
+          fi
+
+          LOGIN_ARGS="--identity \"${{ .variables.CHAINGUARD_IDENTITY }}\""
+          TOKEN=${{ .variables.CHAINGUARD_TOKEN }}
+          if [ -n "$TOKEN" ]; then
+            LOGIN_ARGS="$LOGIN_ARGS --identity-token \"$TOKEN\""
+          fi
+
+          if eval chainctl auth login "$LOGIN_ARGS" -v=0; then
+            echo Logged in as ${{ .variables.CHAINGUARD_IDENTITY }}!
+          else
+            echo Unable to assume the identity ${{ .variables.CHAINGUARD_IDENTITY }}.
+          exit 1
+          fi
+          if ! eval chainctl auth configure-docker "$LOGIN_ARGS" -v=0; then
+            echo Unable to register credential helper as ${{ .variables.CHAINGUARD_IDENTITY }}.
+            exit 1
+          fi
 
       - description: GHCR Registry Login
         if: ${{ ne .variables.GH_TOKEN "" }}

--- a/templates/deploy.yml
+++ b/templates/deploy.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 spec:
@@ -19,6 +19,8 @@ spec:
       default: ${RAPIDFORT_USERNAME}
     rapidfort-password:
       default: ${RAPIDFORT_PASSWORD}
+    chainguard-identity:
+      default: ${CHAINGUARD_IDENTITY}
 ---
 deploy:$[[ inputs.environment ]]:
   script:
@@ -28,6 +30,8 @@ deploy:$[[ inputs.environment ]]:
                                               --set REGISTRY1_PASSWORD="$[[ inputs.registry1-password ]]" \
                                               --set RAPIDFORT_USERNAME="$[[ inputs.rapidfort-username ]]" \
                                               --set RAPIDFORT_PASSWORD="$[[ inputs.rapidfort-password ]]" \
+                                              --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
+                                              --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
                                               --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
                                               --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \

--- a/templates/publish.yml
+++ b/templates/publish.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 spec:
@@ -21,6 +21,8 @@ spec:
       default: ${RAPIDFORT_USERNAME}
     rapidfort-password:
       default: ${RAPIDFORT_PASSWORD}
+    chainguard-identity:
+      default: ${CHAINGUARD_IDENTITY}
     base-repo:
       default: ""
     team:
@@ -38,6 +40,9 @@ publish:
   variables:
     GIT_STRATEGY: clone
     GIT_DEPTH: 0
+  id_tokens:
+    CHAINGUARD_TOKEN:
+      aud: https://console-api.enforce.dev
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -54,6 +59,8 @@ publish:
                                               --set REGISTRY1_PASSWORD="$[[ inputs.registry1-password ]]" \
                                               --set RAPIDFORT_USERNAME="$[[ inputs.rapidfort-username ]]" \
                                               --set RAPIDFORT_PASSWORD="$[[ inputs.rapidfort-password ]]" \
+                                              --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
+                                              --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
                                               --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
                                               --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \

--- a/templates/test.yml
+++ b/templates/test.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 spec:
@@ -22,6 +22,8 @@ spec:
       default: ${RAPIDFORT_USERNAME}
     rapidfort-password:
       default: ${RAPIDFORT_PASSWORD}
+    chainguard-identity:
+      default: ${CHAINGUARD_IDENTITY}
     check-flavor-zarf-yaml:
       default: zarf.yaml
     options:
@@ -30,6 +32,9 @@ spec:
       default: "false"
 ---
 test:
+  id_tokens:
+    CHAINGUARD_TOKEN:
+      aud: https://console-api.enforce.dev
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       when: always
@@ -68,6 +73,8 @@ test:
                                               --set REGISTRY1_PASSWORD="$[[ inputs.registry1-password ]]" \
                                               --set RAPIDFORT_USERNAME="$[[ inputs.rapidfort-username ]]" \
                                               --set RAPIDFORT_PASSWORD="$[[ inputs.rapidfort-password ]]" \
+                                              --set CHAINGUARD_IDENTITY="$[[ inputs.chainguard-identity ]]" \
+                                              --set CHAINGUARD_TOKEN="$CHAINGUARD_TOKEN" \
                                               --set GITLAB_REGISTRY_URL="$CI_REGISTRY" \
                                               --set GITLAB_REGISTRY_USER="$[[ inputs.ci-registry-user ]]" \
                                               --set GITLAB_REGISTRY_TOKEN="$[[ inputs.ci-registry-password ]]" \


### PR DESCRIPTION
## Description

Update `setup-environment` task to allow Chainguard Login in CI.
Tested against [Postgres](https://github.com/uds-packages/postgres-operator/actions/runs/25388872220/job/74457844341?pr=194#step:5:74)

Will comeback later and remove the Rapidfort creds once we have finished migrating.
## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
