### PR TITLE
fix: add id-token:write to auto-update and callable-auto-update workflows

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -16,6 +16,7 @@ permissions:
   contents: write # Allows writing content to the repository.
   packages: read # Allows reading the content of the repository's packages.
   pull-requests: write # Allows creating or updating pull requests.
+  id-token: write # Allows authentication to Chainguard via OIDC. (Needed by callable-auto-update)
 
 # Abort prior jobs in the same workflow / PR
 concurrency:

--- a/.github/workflows/callable-auto-update.yaml
+++ b/.github/workflows/callable-auto-update.yaml
@@ -37,6 +37,7 @@ permissions:
   contents: write # Allows us to read files from the repository for scanning, and writing the bumped releaser.yaml if applicable.
   packages: read # Allows us to pull the sboms from the published packages for comparison.
   pull-requests: write # Allows us to create a PR if needed.
+  id-token: write # Allows authentication to Chainguard via OIDC. (Needed by callable-auto-update-flavor)
 
 jobs:
   get-flavors:


### PR DESCRIPTION
## Description

Fixes token permission errors in `auto-update` and `callable-auto-update` introduced in #664. Because `id-token: write` was added to to `callable-auto-update-flavor` to support Chainguard login, all workflows that call `callable-auto-update-flavor` (i.e. `auto-update` and `callable-auto-update`, as well as any package specific workflows) must also request `id-token: write`. See example erroring workflows below:

https://github.com/uds-packages/neuvector/actions/runs/25683253079
https://github.com/defenseunicorns/uds-common/actions/runs/25678230528
https://github.com/uds-packages/postgres-operator/actions/runs/25678623002


## Checklist before merging

- [X] ADR proposed if making an architectural change to the repo
- [X] Tests run, docs added or updated as needed
