### PR TITLE
chore: swap from oras setup task to shell

### DIFF
--- a/.github/workflows/callable-publish.yaml
+++ b/.github/workflows/callable-publish.yaml
@@ -80,10 +80,8 @@ jobs:
 
       - name: Install ORAS CLI
         if: ${{ inputs.publish-repo }}
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
-        with:
-          # renovate: datasource=github-tags depName=oras-project/oras versioning=semver
-          version: 1.3.1
+        run: uds run actions:install-oras --no-progress
+        shell: bash
 
       - name: Environment setup
         run: |

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -131,6 +131,7 @@ ignore: [] # an array of paths to ignore
 | **debug-output** | Print debug output from a k8s cluster |
 | **clean-gh-runner** | Cleanup unneeded files to free space on a GitHub runner |
 | **install-deps** | Install the runner dependencies for testing UDS Packages |
+| **install-oras** | Install Oras CLI for publishing UDS Packages |
 | **save-logs** | Save Pod and Node logs from a cluster and fix permissions |
 | **setup-environment** | Setup the runner environment for testing UDS Packages |
 | **test-deploy** | Test a deployment of a UDS package/bundle |

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -131,7 +131,7 @@ ignore: [] # an array of paths to ignore
 | **debug-output** | Print debug output from a k8s cluster |
 | **clean-gh-runner** | Cleanup unneeded files to free space on a GitHub runner |
 | **install-deps** | Install the runner dependencies for testing UDS Packages |
-| **install-oras** | Install Oras CLI for publishing UDS Packages |
+| **install-oras** | Install ORAS CLI for OCI artifact operations |
 | **save-logs** | Save Pod and Node logs from a cluster and fix permissions |
 | **setup-environment** | Setup the runner environment for testing UDS Packages |
 | **test-deploy** | Test a deployment of a UDS package/bundle |

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -138,6 +138,21 @@ tasks:
           "https://github.com/defenseunicorns/uds-pk/releases/download/${UDS_PK_VERSION}/uds-pk_${UDS_PK_VERSION}_$(uname -s)_${{ .variables.ARCH }}" \
           && chmod +x /usr/local/bin/uds-pk
 
+  - name: install-oras
+    description: Install ORAS CLI for OCI artifact operations
+    actions:
+      - task: determine-arch
+      - description: Install ORAS CLI
+        env:
+          # renovate: datasource=github-tags depName=oras-project/oras versioning=semver
+          - ORAS_VERSION=v1.3.2
+        cmd: |
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          curl -fsSL \
+            "https://github.com/oras-project/oras/releases/download/${ORAS_VERSION}/oras_${ORAS_VERSION#v}_${OS}_${{ .variables.ARCH }}.tar.gz" \
+            | tar -xz -C /usr/local/bin oras
+          chmod +x /usr/local/bin/oras
+
   - name: authenticate-registries
     description: Log in to the registries for testing and publishing UDS Packages
     actions:


### PR DESCRIPTION
## Description

The [oras-setup](https://github.com/oras-project/setup-oras) action is not often updated and because of this, is often incompatible with the latest Oras CLI versions. Renovate frequently wants to update Oras CLI, which will in-turn break the `oras-setup` task, because it does not often support the latest version. 

This PR is to migrate away from the `oras-setup` task, in favor of creation our own uds-task that will install oras.

Fixes FDRY-112
## Testing
On the dummy package, I bumped releaser and pointed all versions of `uds-common` to this current branch of `ci/oras-setup`, then I published a release. You can see oras successfully setup on the [dummy actions](https://github.com/uds-packages/dummy/actions/runs/26234327144/job/77203110221)

I also created a one-off workflow on dummy to verify oras installs and I verify the [path here](https://github.com/uds-packages/dummy/actions/runs/26234069718/job/77202183376)

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
