### PR TITLE
fix: base repo for release conditional

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,4 +32,5 @@ jobs:
       flavor: ${{ matrix.flavor }}
       runsOn: ${{ matrix.architecture == 'arm64' && 'uds-swf-ubuntu-arm64-4-core' || 'ubuntu-latest' }}
       uds-pk: true
+      options: --set BASE_REPO="ghcr.io/defenseunicorns/packages/uds"
     secrets: inherit # Inherits all secrets from the parent workflow.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,5 +32,5 @@ jobs:
       flavor: ${{ matrix.flavor }}
       runsOn: ${{ matrix.architecture == 'arm64' && 'uds-swf-ubuntu-arm64-4-core' || 'ubuntu-latest' }}
       uds-pk: true
-      options: --set BASE_REPO="ghcr.io/defenseunicorns/packages/uds"
+      base-repo: ghcr.io/defenseunicorns/packages/uds
     secrets: inherit # Inherits all secrets from the parent workflow.


### PR DESCRIPTION
## Description

When publishing a release for `nginx`, the release logic first checks whether the current tag has already been published -- if not, it proceeds with publishing. The check was referencing the wrong OCI path `defenseunicorns/nginx` instead of the correct`defenseunicorns/packages/uds/nginx`, causing the release job to republish nginx on every push to main, regardless of whether the releaser had been updated.

This PR corrects the path used in that check.

[Example of workflow run](https://github.com/defenseunicorns/uds-common/actions/runs/27041157377/job/79817231047#step:8:33)

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
