### PR TITLE
fix: pin grype version in scan job

### DIFF
--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -23,6 +23,11 @@ on:
         description: The prefix for private packages
         default: private
         type: string
+      grypeVersion:
+        description: The uds-cli version to install
+        # renovate: datasource=github-tags depName=anchore/grype versioning=semver
+        default: 0.112.0
+        type: string
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -72,8 +77,11 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           PACKAGE_PREFIX: ${{ inputs.packagePrefix }}
           PRIVATE_PACKAGE_PREFIX: ${{ inputs.privatePackagePrefix }}
+          GRYPE_VERSION: ${{ inputs.grypeVersion }}
         run: |
-          curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin
+          GRYPE_VERSION=
+
+          curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin "${GRYPE_VERSION}"
 
           uds-pk scan compare \
             --public-packages-prefix "${PACKAGE_PREFIX}" \

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -24,7 +24,7 @@ on:
         default: private
         type: string
       grypeVersion:
-        description: The uds-cli version to install
+        description: The grype version to install
         # renovate: datasource=github-tags depName=anchore/grype versioning=semver
         default: v0.112.0
         type: string

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -26,7 +26,7 @@ on:
       grypeVersion:
         description: The uds-cli version to install
         # renovate: datasource=github-tags depName=anchore/grype versioning=semver
-        default: 0.112.0
+        default: v0.112.0
         type: string
 
 # Permissions for the GITHUB_TOKEN used by the workflow.

--- a/.github/workflows/callable-scan.yaml
+++ b/.github/workflows/callable-scan.yaml
@@ -79,8 +79,6 @@ jobs:
           PRIVATE_PACKAGE_PREFIX: ${{ inputs.privatePackagePrefix }}
           GRYPE_VERSION: ${{ inputs.grypeVersion }}
         run: |
-          GRYPE_VERSION=
-
           curl -sSfL https://get.anchore.io/grype | sudo sh -s -- -b /usr/local/bin "${GRYPE_VERSION}"
 
           uds-pk scan compare \


### PR DESCRIPTION
## Description

Pin and renovate version of Grype installed by workflow

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
