### PR TITLE
chore: small docs fix for links and missed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/defenseunicorns/uds-common/release.yaml)](https://github.com/defenseunicorns/uds-common/actions/workflows/release.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-common/badge)](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-common)
 
-This repo acts as a UDS Package Framework that contains common configuration, tasks and documentation useful for building downstream UDS Packages. It defines and helps consumers implement [UDS package practices](./docs/uds-packages/requirements/uds-package-requirements.md) within their specific package repositories and is intended to help streamline keeping those practices up to date over time.
+This repo acts as a UDS Package Framework that contains common configuration, tasks and documentation useful for building downstream UDS Packages. It defines and helps consumers implement [UDS package practices](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/package-requirements/) within their specific package repositories and is intended to help streamline keeping those practices up to date over time.
 
 > [!TIP]
 > Looking for information on how to build a UDS Package? Visit our [Packaging Applications](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/overview/) docs.

--- a/docs/uds-packages/README.md
+++ b/docs/uds-packages/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
 > This document has moved and is no longer maintained in `uds-common`.
-> Visit the new Package Overview documentation [here](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/overview/.
+> Visit the new Package Overview documentation [here](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/overview/).
 >
 > If you need the legacy content, see [uds-common `v1.24.2` docs/uds-packages/README.md](https://github.com/defenseunicorns/uds-common/tree/v1.24.2/docs/uds-packages/README.md).

--- a/docs/uds-packages/README.md
+++ b/docs/uds-packages/README.md
@@ -1,37 +1,5 @@
-> [!WARNING]  
-> This document has been deprecated and is no longer maintained. Visit the new Package Overview [here](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/overview/).
-
-# Quick Start - UDS Packages
-
-This Quick Start is intended to provide the most concise and direct path for creating a UDS package.
-
-> [!TIP]
-> **Why?**
-> Defense Unicorns is focused on making software conveniently available to the warfighter. _wherever the mission may take them_.
+> [!WARNING]
+> This document has moved and is no longer maintained in `uds-common`.
+> Visit the new Package Overview documentation [here](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/overview/.
 >
-> Creating a UDS package makes that piece of software compatible and available in the UDS ecosystem.
-
-<p align="center">
-    <img align="top" src=".images/boromir.png" alt="alt text" width="200">
-    <img src=".images/wat-no-not-that-wat.png" alt="alt text" width="200">
-</p>
-
-If you are working in your own repository.
-- `git clone https://github.com/uds-packages/template.git <app-name>` 
-    - `rm -rf .git/ && git init`
-
-If you are working in https://github.com/uds-packages/
-- Create a new repo and use the uds package template when creating the new repo.
-
-1. Follow the instructions in the [README.md](https://github.com/uds-packages/template/blob/main/README.md) template.
-2. Crosscheck the [UDS Package Requirements](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/requirements/uds-package-requirements.md) -> update as needed
-
-## Resources
-
-- [Guide](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/guide.md): A more comprehensive guide for those wanting a bit more than the TLDR.
-- [Requirements](https://github.com/defenseunicorns/uds-common/blob/main/docs/uds-packages/requirements/uds-package-requirements.md): The requirements for a UDS package.
-- [uds.defenseunicorns.com](https://uds.defenseunicorns.com): The UDS documentation site.
-
-## Experimental Resources
-
-- [UDS Package Kit](https://github.com/defenseunicorns/uds-pk): UDS Package Kit is a tool designed to assist in developing, maintaining, and publishing UDS Packages.
+> If you need the legacy content, see [uds-common `v1.24.2` docs/uds-packages/README.md](https://github.com/defenseunicorns/uds-common/tree/v1.24.2/docs/uds-packages/README.md).

--- a/docs/uds-packages/guidelines/metadata-guidelines.md
+++ b/docs/uds-packages/guidelines/metadata-guidelines.md
@@ -1,5 +1,5 @@
 > [!WARNING]
 > This document has moved and is no longer maintained in `uds-common`.
-> Visit the new Package Metadata documentation [here](https://docs.defenseunicorns.com/core/how-to-guides/packaging-applications/package-metadata/).
+> Visit the new Package Metadata documentation [here](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/package-metadata/).
 >
 > If you need the legacy content, see [uds-common `v1.24.2` docs/uds-packages/guidelines/metadata-guidelines.md](https://github.com/defenseunicorns/uds-common/tree/v1.24.2/docs/uds-packages/guidelines/metadata-guidelines.md).


### PR DESCRIPTION
## Description

@joelmccoy asked for the docs pages to be moved so the link for the metadata was incorrect - also the README was missed in the original update PR.

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
