### PR TITLE
ci: change republish job to manual dispatch

### DIFF
--- a/.github/workflows/republish-package.yaml
+++ b/.github/workflows/republish-package.yaml
@@ -4,17 +4,7 @@
 name: Republish-Package
 
 on:
-  # This workflow is triggered on pull requests to the main branch.
-  pull_request:
-    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
-    types: [milestoned, opened, reopened, synchronize]
-    # Will only rerun if files affecting this workflow are edited
-    paths:
-      - .github/workflows/callable-republish-package.yaml
-      - .github/workflows/republish-package.yaml
-      - tasks/actions.yaml
-      - tasks/create.yaml
-      - tasks/publish.yaml
+  workflow_dispatch:
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=nginx
-    version: 1.31.1-uds.0
+    version: 1.31.1-uds.1
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/nginx/nginx
-    version: 1.30.2-uds.0
+    version: 1.30.2-uds.1
   - name: unicorn
     # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/nginx extractVersion=^v?(?<version>.*)$
-    version: 1.31.1-uds.0
+    version: 1.31.1-uds.1


### PR DESCRIPTION
## Description

- Change republish job to only run on manual dispatch instead of on PRs

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
