### PR TITLE
chore: add a renovate rule to check for versions afer a slash

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -180,6 +180,22 @@
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
             "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
         },
+        // Matches specified datasources where a slash separates the version at the end of the following line (i.e. a certificateIdentity URL like https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/v0.78.0)
+        {
+            "customType": "regex",
+            "fileMatch": [
+                ".*\\.ya?ml$",
+                ".*\\.md$"
+            ],
+            "matchStrings": [
+                // Test: https://regex101.com/r/OJIxfQ/1
+                "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)",
+                // Test: https://regex101.com/r/K9vN3r/1
+                "<!-- renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))? -->\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)"
+            ],
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+            "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"
+        },
         // Matches specified datasources where a Go variable assignment (:= or =) separates the version on the following line
         {
             "customType": "regex",

--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -188,10 +188,10 @@
                 ".*\\.md$"
             ],
             "matchStrings": [
-                // Test: https://regex101.com/r/OJIxfQ/1
-                "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)",
-                // Test: https://regex101.com/r/K9vN3r/1
-                "<!-- renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))? -->\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)"
+                // Test: https://regex101.com/r/VJP7jP/1
+                "# renovate-slash: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)",
+                // Test: https://regex101.com/r/EEN8mM/1
+                "<!-- renovate-slash: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?( registryUrl=(?<registryUrl>.*?))? -->\\s.*\\/(?<currentValue>[^\\/'\"\\s]*)['\"]?(\\s|$)"
             ],
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
             "extractVersionTemplate": "{{#if extractVersion}}{{{extractVersion}}}{{else}}^(?<version>.*)${{/if}}"


### PR DESCRIPTION
## Description

This adds a renovate rule to find versions after a slash.  The prefix `# renovate-slash` is used because otherwise it could overlap with the colon rule - this is possible to workaround with ordering but it felt safer to have a namespace.

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
