### PR TITLE
chore: have renovate pin actions to full semver

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -5,7 +5,8 @@
     "extends": [
         ":dependencyDashboard",
         "config:base",
-        "helpers:pinGitHubActionDigests"
+        "helpers:pinGitHubActionDigests",
+        "helpers:pinGitHubActionDigestsToSemver"
     ],
     // Include test folders in checks
     "ignorePresets": [


### PR DESCRIPTION
## Description

https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver

This setting ensures that all actions are pinned with their full semver in the comment (removing the need for [manual PRs like this](https://github.com/defenseunicorns/uds-common/pull/728)).