### PR TITLE
fix(bug): tighten upgrade check to use latest git tag

### DIFF
--- a/.github/actions/test-flavor/action.yaml
+++ b/.github/actions/test-flavor/action.yaml
@@ -27,18 +27,17 @@ runs:
 
     - name: Test latest tag deployment for flavor
       id: set-required
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        # Check if any tag exists
-        TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null || echo '')"
+        # Use the latest published release tag, not bare git tags, to avoid pointing at failed releases
+        TAG="$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' 2>/dev/null || echo '')"
 
         if [ -z "$TAG" ]; then
-          echo "No Git tags found. Skipping step."
+          echo "No releases found. Skipping step."
           exit 0
         fi
 
-        # Checkout the repository at the latest tag
-        git checkout "$TAG"
-
         # Extract upgrade flavors and set output
-        echo "upgrade-flavors=$(cat ${{ inputs.check-flavor-zarf-yaml }} | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
+        echo "upgrade-flavors=$(git show "$TAG:${{ inputs.check-flavor-zarf-yaml }}" | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, - || echo '')" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
## Description

Fixes upgrade flavor detection incorrectly reading `zarf.yaml` from a failed or non-existent release.

Previously, `test-flavor/action.yaml` used `git describe --tags` to find the latest tag and checked out that ref to determine which flavors support upgrade testing. Git tags are pushed at the start of the release process, so a tag can exist even when the corresponding publish failed — causing the action to infer upgrade behavior from a release that was never actually available (as seen in the `uds-package/chainloop` arm64 publish run).

The action now queries the GitHub Releases API (`gh release list`) instead, which only returns completed, non-draft releases. The `zarf.yaml` is read directly from that ref with `git show` rather than a working-tree checkout.

## How to test

1. Authenticate the GitHub CLI if needed:
	```bash
	gh auth login
	```
2. Run the same lookup the action uses and confirm it returns the latest published release tag:
	```bash
	TAG="$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' 2>/dev/null || echo '')"
	echo "$TAG"
	```
3. Verify flavor extraction from that release ref:
	```bash
	git show "$TAG:zarf.yaml" | yq '.components[] | select(.only | has("flavor")) | .only.flavor' | paste -s -d, -
	```
4. Confirm the empty-release case exits cleanly:
	```bash
	TAG=""
	if [ -z "$TAG" ]; then echo "No releases found. Skipping step."; fi
	```

## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
