### PR TITLE
fix: fix renovate regex for postgres operator

### DIFF
--- a/config/renovate.json5
+++ b/config/renovate.json5
@@ -375,7 +375,7 @@
             ],
             "datasourceTemplate": "docker",
             // Match versioning used on UDS packages. Test: https://regex101.com/r/BGkYHX/4
-            "versioningTemplate": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-uds\\.(?<build>\\d))?(-(?<compatibility>\\w+)?)?(.*?)?$"
+            "versioningTemplate": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(-uds\\.(?<build>\\d+))?(-(?<compatibility>\\w+)?)?(.*?)?$"
         },
         // Matches playwright docker image tags, set by default for packages in package template: https://github.com/uds-packages/template/blob/3df17ca97a778dd3acb25fab47b3d38e59b663ea/tasks/test.yaml#L71
         {


### PR DESCRIPTION
## Description

Support multiple digits in the build number.  For example `1.15.1-uds.28-unicorn`

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [ ] Tests run, docs added or updated as needed
