### PR TITLE
fix: add a timeout sudo for save logs

### DIFF
--- a/.github/workflows/callable-test.yaml
+++ b/.github/workflows/callable-test.yaml
@@ -165,6 +165,7 @@ jobs:
         if: ${{ always() }}
         run: uds run actions:save-logs
         shell: bash
+        timeout-minutes: 2
 
       - name: Generate unique suffix
         id: uniq

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -103,8 +103,8 @@ tasks:
 
       - description: Fix log permissions
         cmd: |
-          sudo chown "$USER" ${{ .variables.LOG_DIR }}/zarf-*.log || echo ""
-          sudo chown "$USER" ${{ .variables.LOG_DIR }}/uds-*.log || echo ""
+          timeout 30s sudo -n chown "$USER" ${{ .variables.LOG_DIR }}/zarf-*.log || echo ""
+          timeout 30s sudo -n chown "$USER" ${{ .variables.LOG_DIR }}/uds-*.log || echo ""
 
   - name: setup-environment
     description: Setup the runner environment for testing UDS Packages

--- a/tasks/actions.yaml
+++ b/tasks/actions.yaml
@@ -103,8 +103,8 @@ tasks:
 
       - description: Fix log permissions
         cmd: |
-          timeout 30s sudo -n chown "$USER" ${{ .variables.LOG_DIR }}/zarf-*.log || echo ""
-          timeout 30s sudo -n chown "$USER" ${{ .variables.LOG_DIR }}/uds-*.log || echo ""
+          timeout 20s sudo chown "$USER" ${{ .variables.LOG_DIR }}/zarf-*.log || echo ""
+          timeout 20s sudo chown "$USER" ${{ .variables.LOG_DIR }}/uds-*.log || echo ""
 
   - name: setup-environment
     description: Setup the runner environment for testing UDS Packages


### PR DESCRIPTION
## Description

Occasionally my CI jobs get hung on the `save-logs` step in the test workflow. I suspect that this is due to sudo waiting for authentication. So I added `timeout 30s` (job normally only takes 1-2s at most), and a `-n` to ensure its non-interactive.

Links to jobs that run into this problem:
[Jenkins](https://github.com/uds-packages/jenkins/actions/runs/31726818099/job/94537233683)
[Jira](https://github.com/uds-packages/jira/actions/runs/31729698468/job/94546831350)

## Checklist before merging

- [ ] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
