### PR TITLE
chore: pass version input for commitlint

### DIFF
--- a/.github/workflows/callable-commitlint.yaml
+++ b/.github/workflows/callable-commitlint.yaml
@@ -12,6 +12,11 @@ on:
 
   # This allows other repositories to call this workflow in a reusable way
   workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version to use for commitlint
+        required: false
+        type: string
 
 # Permissions for the GITHUB_TOKEN used by the workflow.
 permissions:
@@ -33,6 +38,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Install commitlint
         run: |


### PR DESCRIPTION
## Description
- Adds an optional node-version input to the reusable commitlint workflow.
- When omitted, existing runner-default behavior is unchanged.

Can be called like the following
```yaml
with:
  node-version: "24"
```

## WHY
- Dependency-operator uses Node 24, but the shared commitlint workflow falls back to Node 22/npm 10. npm fails while installing commitlint in that environment.
This change lets dependency-operator run commitlint with Node 24.
This lets callers run commitlint with their supported Node version.
- Failure Example: https://github.com/defenseunicorns/dependency-operator/actions/runs/34251025675/job/102555029168?pr=128

## TESTING
 https://github.com/defenseunicorns/dependency-operator/pull/131
## Checklist before merging

- [x] ADR proposed if making an architectural change to the repo
- [x] Tests run, docs added or updated as needed
